### PR TITLE
Add `bool $preserveKeys = true` to Teds\Vector::__construct

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,8 @@
  <date>2021-09-10</date>
  <time>16:00:00</time>
  <version>
-  <release>0.1.2dev</release>
-  <api>0.1.2dev</api>
+  <release>0.2.0dev</release>
+  <api>0.2.0dev</api>
  </version>
  <stability>
   <release>alpha</release>
@@ -22,7 +22,10 @@
  </stability>
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* Convert references to non-references when creating values from iterables
+* Breaking change: Change `Teds\Vector::__construct` to add an additional parameter `bool $preserveKeys = true`,
+  and use the original keys of arrays/Traversables by default, throwing for non-integers and invalid integer offsets.
+  (Similar to the behavior of SplFixedArray::fromArray)
+* Convert references to non-references when creating values from iterables.
  </notes>
  <contents>
   <dir name="/">
@@ -134,6 +137,7 @@
     <file name="Vector/shrink_capacity.phpt" role="test" />
     <file name="Vector/toArray.phpt" role="test" />
     <file name="Vector/traversable.phpt" role="test" />
+    <file name="Vector/traversable_preserve_keys.phpt" role="test" />
     <file name="Vector/unserialize.phpt" role="test" />
     <file name="iterable/all_array.phpt" role="test" />
     <file name="iterable/all_traversable.phpt" role="test" />

--- a/php_teds.h
+++ b/php_teds.h
@@ -23,7 +23,7 @@ extern zend_module_entry teds_module_entry;
 
 PHP_MINIT_FUNCTION(teds);
 
-# define PHP_TEDS_VERSION "0.1.1"
+# define PHP_TEDS_VERSION "0.2.0dev"
 
 # if defined(ZTS) && defined(COMPILE_DL_TEDS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/teds_vector.stub.php
+++ b/teds_vector.stub.php
@@ -6,7 +6,14 @@ namespace Teds;
 
 final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
 {
-    public function __construct(iterable $iterator = []) {}
+    /**
+     * Construct a Vector from an iterable.
+     *
+     * When $preserveKeys is false, the values will be reindexed without gaps starting from 0
+     * When $preserveKeys is true, any gaps in the keys of the iterable will be filled in with null,
+     * and negative indices or non-integer indices will be rejected and cause an Exception.
+     */
+    public function __construct(iterable $iterator = [], bool $preserveKeys = true) {}
     public function getIterator(): \InternalIterator {}
     public function count(): int {}
     public function capacity(): int {}
@@ -24,10 +31,11 @@ final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable,
     // Strictly typed, unlike offsetGet/offsetSet
     public function valueAt(int $offset): mixed {}
     public function setValueAt(int $offset, mixed $value): void {}
+
     public function offsetGet(mixed $offset): mixed {}
     public function offsetExists(mixed $offset): bool {}
     public function offsetSet(mixed $offset, mixed $value): void {}
-    // Throws
+    // Throws because unset and null are different things, unlike SplFixedArray
     public function offsetUnset(mixed $offset): void {}
 
     public function indexOf(mixed $value): int|false {}

--- a/teds_vector_arginfo.h
+++ b/teds_vector_arginfo.h
@@ -1,8 +1,9 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 20550cb51b110c1c2400447292a5fa9aab111eb5 */
+ * Stub hash: e6e00e028a0d61165c44436c27b23c53175f6db8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Vector___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, preserveKeys, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_Vector_getIterator, 0, 0, InternalIterator, 0)

--- a/tests/Vector/Vector.phpt
+++ b/tests/Vector/Vector.phpt
@@ -3,7 +3,7 @@ Teds\Vector constructed from array
 --FILE--
 <?php
 // discards keys
-$it = new Teds\Vector(['first' => 'x', 'second' => new stdClass()]);
+$it = new Teds\Vector(['first' => 'x', 'second' => new stdClass()], preserveKeys: false);
 foreach ($it as $key => $value) {
     printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
 }
@@ -17,6 +17,21 @@ foreach ($it as $key => $value) {
     echo "Unreachable\n";
 }
 
+// The default is to preserve keys
+$it = new Teds\Vector([2 => 'third', 0 => 'first']);
+var_dump($it);
+
+try {
+    $it = new Teds\Vector([-1 => new stdClass()]);
+} catch (UnexpectedValueException $e) {
+    echo "Caught: {$e->getMessage()}\n";
+}
+
+try {
+    $it = new Teds\Vector(['0a' => new stdClass()]);
+} catch (UnexpectedValueException $e) {
+    echo "Caught: {$e->getMessage()}\n";
+}
 ?>
 --EXPECT--
 Key: 0
@@ -42,3 +57,13 @@ object(Teds\Vector)#3 (0) {
 }
 array(0) {
 }
+object(Teds\Vector)#1 (3) {
+  [0]=>
+  string(5) "first"
+  [1]=>
+  NULL
+  [2]=>
+  string(5) "third"
+}
+Caught: array must contain only positive integer keys
+Caught: array must contain only positive integer keys

--- a/tests/Vector/aggregate.phpt
+++ b/tests/Vector/aggregate.phpt
@@ -3,7 +3,7 @@ Teds\Vector is an IteratorAggregate
 --FILE--
 <?php
 
-$it = new Teds\Vector(['discarded_first' => 'x', 'discardedsecond' => (object)['key' => 'value']]);
+$it = new Teds\Vector(['x', (object)['key' => 'value']]);
 foreach ($it as $k1 => $v1) {
     foreach ($it as $k2 => $v2) {
         printf("k1=%s k2=%s v1=%s v2=%s\n", json_encode($k1), json_encode($k2), json_encode($v1), json_encode($v2));

--- a/tests/Vector/exceptionhandler.phpt
+++ b/tests/Vector/exceptionhandler.phpt
@@ -21,7 +21,7 @@ function yields_and_throws() {
     echo "Unreachable\n";
 }
 try {
-    $it = new Teds\Vector(yields_and_throws());
+    $it = new Teds\Vector(yields_and_throws(), preserveKeys: false);
 } catch (RuntimeException $e) {
     echo "Caught " . $e->getMessage() . "\n";
 }

--- a/tests/Vector/offsetGet.phpt
+++ b/tests/Vector/offsetGet.phpt
@@ -12,7 +12,7 @@ function expect_throws(Closure $cb): void {
     }
 }
 expect_throws(fn() => (new ReflectionClass(Teds\Vector::class))->newInstanceWithoutConstructor());
-$it = new Teds\Vector(['first' => new stdClass()]);
+$it = new Teds\Vector([new stdClass()]);
 var_dump($it->offsetGet(0));
 var_dump($it->valueAt(0));
 expect_throws(fn() => $it->offsetSet(1,'x'));

--- a/tests/Vector/serialization.phpt
+++ b/tests/Vector/serialization.phpt
@@ -3,7 +3,7 @@ Teds\Vector can be serialized and unserialized
 --FILE--
 <?php
 
-$it = new Teds\Vector(['first' => new stdClass()]);
+$it = new Teds\Vector(['first' => new stdClass()], preserveKeys: false);
 try {
     $it->dynamicProp = 123;
 } catch (Throwable $t) {

--- a/tests/Vector/toArray.phpt
+++ b/tests/Vector/toArray.phpt
@@ -3,7 +3,7 @@ Teds\Vector toArray()
 --FILE--
 <?php
 
-$it = new Teds\Vector(['first' => new stdClass()]);
+$it = new Teds\Vector(['first' => new stdClass()], false);
 var_dump($it->toArray());
 var_dump($it->toArray());
 $it = new Teds\Vector([]);

--- a/tests/Vector/traversable.phpt
+++ b/tests/Vector/traversable.phpt
@@ -15,7 +15,7 @@ function yields_values() {
 }
 
 // Teds\Vector eagerly evaluates the passed in Traversable
-$it = new Teds\Vector(yields_values());
+$it = new Teds\Vector(yields_values(), preserveKeys: false);
 foreach ($it as $key => $value) {
     printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
 }
@@ -25,16 +25,18 @@ foreach ($it as $key => $value) {
 }
 unset($it);
 
-$emptyIt = new Teds\Vector(new ArrayObject());
-var_dump($emptyIt);
-foreach ($emptyIt as $key => $value) {
-    echo "Unreachable\n";
+foreach ([false, true] as $preserveKeys) {
+    $emptyIt = new Teds\Vector(new ArrayObject(), $preserveKeys);
+    var_dump($emptyIt);
+    foreach ($emptyIt as $key => $value) {
+        echo "Unreachable\n";
+    }
+    foreach ($emptyIt as $key => $value) {
+        echo "Unreachable\n";
+    }
+    echo "Done\n";
+    unset($emptyIt);
 }
-foreach ($emptyIt as $key => $value) {
-    echo "Unreachable\n";
-}
-echo "Done\n";
-
 
 ?>
 --EXPECT--
@@ -96,6 +98,9 @@ Key: 11
 Value: 1
 Key: 12
 Value: 2
+object(Teds\Vector)#1 (0) {
+}
+Done
 object(Teds\Vector)#1 (0) {
 }
 Done

--- a/tests/Vector/traversable_preserve_keys.phpt
+++ b/tests/Vector/traversable_preserve_keys.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Vector constructed from Traversable preserves keys
+--FILE--
+<?php
+
+use Teds\Vector;
+
+function yields_values() {
+    yield 5 => (object)['key' => 'value'];
+    yield 0 => new stdClass();;
+    yield 0 => true;
+}
+
+function yields_bad_value() {
+    yield 5 => (object)['key' => 'value'];
+    yield -1 => new stdClass();
+}
+
+// Vector eagerly evaluates the passed in Traversable
+$it = new Vector(yields_values());
+foreach ($it as $key => $value) {
+    printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
+}
+printf("count=%d capacity=%d\n", $it->count(), $it->capacity());
+unset($it);
+
+try {
+    $it = new Vector(yields_bad_value());
+} catch (Exception $e) {
+    printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+}
+
+?>
+--EXPECT--
+Key: 0
+Value: true
+Key: 1
+Value: NULL
+Key: 2
+Value: NULL
+Key: 3
+Value: NULL
+Key: 4
+Value: NULL
+Key: 5
+Value: (object) array(
+   'key' => 'value',
+)
+count=6 capacity=6
+Caught UnexpectedValueException: array must contain only positive integer keys


### PR DESCRIPTION
This is a backwards incompatible change for anything that would pass in
iterables with non-integer keys or keys that weren't 0..size-1
The new behavior is similar to SplFixedArray::fromArray.

Pass in `preserveKeys: false` for the old behavior.