### PR TITLE
Minor performance improvements, add a benchmark

### DIFF
--- a/benchmarks/benchmark_vector.php
+++ b/benchmarks/benchmark_vector.php
@@ -1,0 +1,138 @@
+<?php
+
+use Teds\Vector;
+
+function bench_array(int $n, int $iterations) {
+    $totalReadTime = 0.0;
+    $startTime = hrtime(true);
+    $total = 0;
+    for ($j = 0; $j < $iterations; $j++) {
+        $startMemory = memory_get_usage();
+        $values = [];
+        for ($i = 0; $i < $n; $i++) {
+            $values[] = $i;
+        }
+        $startReadTime = hrtime(true);
+        for ($i = 0; $i < $n; $i++) {
+            $total += $values[$i];
+        }
+        $endReadTime = hrtime(true);
+        $totalReadTime += $endReadTime - $startReadTime;
+
+        $endMemory = memory_get_usage();
+        unset($values);
+    }
+    $endTime = hrtime(true);
+
+    $totalTime = ($endTime - $startTime) / 1000000000;
+    $totalReadTimeSeconds = $totalReadTime / 1000000000;
+    printf("Appending to array:         n=%8d iterations=%8d memory=%8d bytes, create+destroy time=%.3f read time = %.3f result=%d\n",
+        $n, $iterations, $endMemory - $startMemory, $totalTime - $totalReadTimeSeconds, $totalReadTimeSeconds, $total);
+}
+function bench_vector(int $n, int $iterations) {
+    $startTime = hrtime(true);
+    $totalReadTime = 0.0;
+    $total = 0;
+    for ($j = 0; $j < $iterations; $j++) {
+        $startMemory = memory_get_usage();
+        $values = new Vector();
+        for ($i = 0; $i < $n; $i++) {
+            $values->push($i);
+        }
+
+        $startReadTime = hrtime(true);
+        for ($i = 0; $i < $n; $i++) {
+            $total += $values[$i];
+        }
+        $endReadTime = hrtime(true);
+        $totalReadTime += $endReadTime - $startReadTime;
+
+        $endMemory = memory_get_usage();
+        unset($values);
+    }
+    $endTime = hrtime(true);
+    $totalTime = ($endTime - $startTime) / 1000000000;
+    $totalReadTimeSeconds = $totalReadTime / 1000000000;
+    printf("Appending to Vector:        n=%8d iterations=%8d memory=%8d bytes, create+destroy time=%.3f read time = %.3f result=%d\n",
+        $n, $iterations, $endMemory - $startMemory, $totalTime - $totalReadTimeSeconds, $totalReadTimeSeconds, $total);
+}
+// SplStack is a subclass of SplDoublyLinkedList, so it is a linked list that takes more memory than needed.
+// Access to values in the middle of the SplStack is also less efficient.
+function bench_spl_stack(int $n, int $iterations) {
+    $startTime = hrtime(true);
+    $totalReadTime = 0.0;
+    $total = 0;
+    for ($j = 0; $j < $iterations; $j++) {
+        $startMemory = memory_get_usage();
+        $values = new SplStack();
+        for ($i = 0; $i < $n; $i++) {
+            $values->push($i);
+        }
+        $startReadTime = hrtime(true);
+        // Random access is linear time in a linked list, so use foreach instead
+        foreach ($values as $value) {
+            $total += $value;
+        }
+        $endReadTime = hrtime(true);
+        $totalReadTime += $endReadTime - $startReadTime;
+        $endMemory = memory_get_usage();
+        unset($values);
+    }
+    $endTime = hrtime(true);
+    $totalTime = ($endTime - $startTime) / 1000000000;
+    $totalReadTimeSeconds = $totalReadTime / 1000000000;
+    printf("Appending to SplStack:      n=%8d iterations=%8d memory=%8d bytes, create+destroy time=%.3f read time = %.3f result=%d\n",
+        $n, $iterations, $endMemory - $startMemory, $totalTime - $totalReadTimeSeconds, $totalReadTimeSeconds, $total);
+}
+function bench_spl_fixed_array(int $n, int $iterations) {
+    $startTime = hrtime(true);
+    $totalReadTime = 0.0;
+    $total = 0;
+    for ($j = 0; $j < $iterations; $j++) {
+        $startMemory = memory_get_usage();
+        $values = new SplFixedArray();
+        for ($i = 0; $i < $n; $i++) {
+            // Imitate how push() would be implemented in a situation
+            // where the number of elements wasn't actually known ahead of time.
+            // erealloc() tends to extend the existing array when possible.
+            $size = $values->getSize();
+            $values->setSize($size + 1);
+            $values->offsetSet($size, $i);
+        }
+        $startReadTime = hrtime(true);
+        for ($i = 0; $i < $n; $i++) {
+            $total += $values[$i];
+        }
+        $endReadTime = hrtime(true);
+        $totalReadTime += $endReadTime - $startReadTime;
+        $endMemory = memory_get_usage();
+        unset($values);
+    }
+    $endTime = hrtime(true);
+    $totalTime = ($endTime - $startTime) / 1000000000;
+    $totalReadTimeSeconds = $totalReadTime / 1000000000;
+    printf("Appending to SplFixedArray: n=%8d iterations=%8d memory=%8d bytes, create+destroy time=%.3f read time = %.3f result=%d\n\n",
+        $n, $iterations, $endMemory - $startMemory, $totalTime - $totalReadTimeSeconds, $totalReadTimeSeconds, $total);
+}
+$n = 2**20;
+$iterations = 10;
+$sizes = [
+    [1, 8000000],
+    [4, 2000000],
+    [8, 1000000],
+    [2**20, 20],
+];
+printf(
+    "Results for php %s debug=%s with opcache enabled=%s\n\n",
+    PHP_VERSION,
+    PHP_DEBUG ? 'true' : 'false',
+    json_encode(function_exists('opcache_get_status') && (opcache_get_status(false)['opcache_enabled'] ?? false))
+);
+
+foreach ($sizes as [$n, $iterations]) {
+    bench_array($n, $iterations);
+    bench_vector($n, $iterations);
+    bench_spl_stack($n, $iterations);
+    bench_spl_fixed_array($n, $iterations);
+    echo "\n";
+}

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   and use the original keys of arrays/Traversables by default, throwing for non-integers and invalid integer offsets.
   (Similar to the behavior of SplFixedArray::fromArray)
 * Convert references to non-references when creating values from iterables.
+* Minor performance improvements of `Teds\Vector`
  </notes>
  <contents>
   <dir name="/">

--- a/teds.h
+++ b/teds.h
@@ -61,7 +61,7 @@ static zend_always_inline zend_long teds_get_offset(const zval *offset) {
 }
 
 #define CONVERT_OFFSET_TO_LONG_OR_THROW(index, zv) do { \
-	if (Z_TYPE_P(offset_zv) != IS_LONG) { \
+	if (UNEXPECTED(Z_TYPE_P(offset_zv) != IS_LONG)) { \
 		index = teds_get_offset(offset_zv); \
 		if (UNEXPECTED(EG(exception))) { \
 			return; \
@@ -72,7 +72,7 @@ static zend_always_inline zend_long teds_get_offset(const zval *offset) {
 } while(0)
 
 #define CONVERT_OFFSET_TO_LONG_OR_THROW_RETURN_NULLPTR(index, zv) do { \
-	if (Z_TYPE_P(offset_zv) != IS_LONG) { \
+	if (UNEXPECTED(Z_TYPE_P(offset_zv) != IS_LONG)) { \
 		index = teds_get_offset(offset_zv); \
 		if (UNEXPECTED(EG(exception))) { \
 			return NULL; \

--- a/teds_vector.c
+++ b/teds_vector.c
@@ -1088,7 +1088,7 @@ static void teds_vector_write_dimension(zend_object *object, zval *offset_zv, zv
 
 static zval *teds_vector_read_dimension(zend_object *object, zval *offset_zv, int type, zval *rv)
 {
-	if (!offset_zv) {
+	if (UNEXPECTED(!offset_zv)) {
 		zend_throw_exception(spl_ce_RuntimeException, "[] operator not supported for Teds\\Vector", 0);
 		return NULL;
 	}
@@ -1098,7 +1098,7 @@ static zval *teds_vector_read_dimension(zend_object *object, zval *offset_zv, in
 
 	const teds_vector *intern = teds_vector_from_object(object);
 
-	if (offset < 0 || offset >= intern->array.size) {
+	if (UNEXPECTED(offset < 0 || offset >= intern->array.size)) {
 		if (type != BP_VAR_IS) {
 			zend_throw_exception(spl_ce_OutOfBoundsException, "Index out of range", 0);
 		}


### PR DESCRIPTION
This is lower memory than array and faster than SplStack/SplFixedArray.
`benchmarks/benchmark_vector.php` can be used to test this.

Due to Zend having specializations and optimizations for arrays, this
isn't close to as fast for reads, though.