### PR TITLE
Work on making final adjustments to Vector API

### DIFF
--- a/benchmarks/benchmark_vector.php
+++ b/benchmarks/benchmark_vector.php
@@ -66,6 +66,9 @@ function bench_spl_stack(int $n, int $iterations) {
         $startMemory = memory_get_usage();
         $values = new SplStack();
         for ($i = 0; $i < $n; $i++) {
+            // XXX: For SplStack, $values[] = $value is unexpectedly twice as slow as push($value)
+            // due to the lack of custom handlers and falling back to the default ArrayAccess->offsetSet call.
+            // This could probably be improved.
             $values->push($i);
         }
         $startReadTime = hrtime(true);

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -9,7 +9,9 @@ ADD *.sh *.c *.h *.php *.md config.m4 config.w32 package.xml COPYING ./
 
 # Assume compilation will be the time consuming step.
 # Add tests after compiling so that it's faster to update tests and re-run them locally.
-RUN phpize && ./configure && make -j2 && make install
+#
+# Use extremely strict CFLAGS for checking correctness of code before merging it.
+RUN export CFLAGS='-Wall -Wextra -Werror -Wno-unused-parameter'; phpize && ./configure && make -j$(nproc) && make install
 RUN docker-php-ext-enable teds
 ADD tests ./tests
 ADD ci ./ci

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
 * Backwards incompatible change: Change `Vector::indexOf` return type from `int|false` to `?int` (and all other `indexOf*` methods in other data structures)
+* Backwards incompatible change: Change `valueAt`/`setValueAt` to get/set in Deque, Vector, and ImmutableSequence
 * Add optional parameter `$value = null` to `Vector::setSize()` to allow overriding the value used for padding when lengthening an array.
 * Change exception handling for sizes/capacities that are definitely too large to allocate.
  </notes>

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,8 @@
  <date>2021-09-16</date>
  <time>16:00:00</time>
  <version>
-  <release>0.2.1</release>
-  <api>0.2.1</api>
+  <release>0.3.0dev</release>
+  <api>0.3.0dev</api>
  </version>
  <stability>
   <release>alpha</release>
@@ -22,8 +22,9 @@
  </stability>
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* Support `$vector[] = $value` and `$deque[] = $value` assignments to append to Vector/Deque.
-* Add map() and filter() functions to Vector.
+* Backwards incompatible change: Change `Vector::indexOf` return type from `int|false` to `?int` (and all other `indexOf*` methods in other data structures)
+* Add optional parameter `$value = null` to `Vector::setSize()` to allow overriding the value used for padding when lengthening an array.
+* Change exception handling for sizes/capacities that are definitely too large to allocate.
  </notes>
  <contents>
   <dir name="/">
@@ -131,8 +132,10 @@
     <file name="Vector/offsetGet.phpt" role="test" />
     <file name="Vector/push_pop.phpt" role="test" />
     <file name="Vector/reinit_forbidden.phpt" role="test" />
+    <file name="Vector/reserve.phpt" role="test" />
     <file name="Vector/serialization.phpt" role="test" />
     <file name="Vector/setSize.phpt" role="test" />
+    <file name="Vector/setSize_default.phpt" role="test" />
     <file name="Vector/setValueAt.phpt" role="test" />
     <file name="Vector/set_state.phpt" role="test" />
     <file name="Vector/shrink_capacity.phpt" role="test" />
@@ -167,6 +170,21 @@
  <providesextension>teds</providesextension>
  <extsrcrelease />
  <changelog>
+  <date>2021-09-16</date>
+  <time>16:00:00</time>
+  <version>
+   <release>0.2.1</release>
+   <api>0.2.1</api>
+  </version>
+  <stability>
+   <release>alpha</release>
+   <api>alpha</api>
+  </stability>
+  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
+  <notes>
+* Support `$vector[] = $value` and `$deque[] = $value` assignments to append to Vector/Deque.
+* Add map() and filter() functions to Vector.
+  </notes>
   <release>
    <date>2021-09-12</date>
    <time>16:00:00</time>

--- a/php_teds.h
+++ b/php_teds.h
@@ -23,7 +23,7 @@ extern zend_module_entry teds_module_entry;
 
 PHP_MINIT_FUNCTION(teds);
 
-# define PHP_TEDS_VERSION "0.2.1"
+# define PHP_TEDS_VERSION "0.3.0dev"
 
 # if defined(ZTS) && defined(COMPILE_DL_TEDS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/teds.h
+++ b/teds.h
@@ -51,8 +51,9 @@ static zend_always_inline zend_long teds_get_offset(const zval *offset) {
 			offset = Z_REFVAL_P(offset);
 			goto try_again;
 		case IS_RESOURCE:
+			/* The type changed from int to zend_long in php 8.1. This is not really important in practice. */
 			zend_error(E_WARNING, "Resource ID#" ZEND_LONG_FMT " used as offset, casting to integer (" ZEND_LONG_FMT ")",
-				Z_RES_HANDLE_P(offset), Z_RES_HANDLE_P(offset));
+				(zend_long)Z_RES_HANDLE_P(offset), (zend_long)Z_RES_HANDLE_P(offset));
 			return Z_RES_HANDLE_P(offset);
 	}
 

--- a/teds_deque.c
+++ b/teds_deque.c
@@ -25,6 +25,7 @@
 #include "ext/spl/spl_exceptions.h"
 #include "ext/spl/spl_iterators.h"
 #include "ext/json/php_json.h"
+#include "teds_util.h"
 
 #include <stdbool.h>
 
@@ -468,7 +469,7 @@ static int teds_deque_it_valid(zend_object_iterator *iter)
 	const teds_deque_it *iterator = (teds_deque_it*)iter;
 	const teds_deque *object = Z_DEQUE_P(&iter->data);
 
-	if (iterator->current >= 0 && iterator->current < object->array.size) {
+	if (iterator->current >= 0 && (zend_ulong) iterator->current < object->array.size) {
 		return SUCCESS;
 	}
 
@@ -687,7 +688,7 @@ static zend_always_inline void teds_deque_get_value_at_offset(zval *return_value
 	RETURN_COPY(teds_deque_get_entry_at_offset(&intern->array, offset));
 }
 
-PHP_METHOD(Teds_Deque, valueAt)
+PHP_METHOD(Teds_Deque, get)
 {
 	zend_long offset;
 	ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -740,7 +741,7 @@ static zval *teds_deque_read_dimension(zend_object *object, zval *offset_zv, int
 
 	const teds_deque *intern = teds_deque_from_object(object);
 
-	if (offset < 0 || offset >= intern->array.size) {
+	if (offset < 0 || (zend_ulong) offset >= intern->array.size) {
 		if (type != BP_VAR_IS) {
 			zend_throw_exception(spl_ce_OutOfBoundsException, "Index out of range", 0);
 		}
@@ -789,7 +790,7 @@ static void teds_deque_write_dimension(zend_object *object, zval *offset_zv, zva
 	CONVERT_OFFSET_TO_LONG_OR_THROW(offset, offset_zv);
 
 	const teds_deque *intern = teds_deque_from_object(object);
-	if (offset < 0 || offset >= intern->array.size) {
+	if (offset < 0 || (zend_ulong) offset >= intern->array.size) {
 		zend_throw_exception(spl_ce_RuntimeException, "Index invalid or out of range", 0);
 		return;
 	}
@@ -833,7 +834,7 @@ PHP_METHOD(Teds_Deque, contains)
 	RETURN_FALSE;
 }
 
-PHP_METHOD(Teds_Deque, setValueAt)
+PHP_METHOD(Teds_Deque, set)
 {
 	zend_long offset;
 	zval *value;
@@ -862,7 +863,8 @@ PHP_METHOD(Teds_Deque, offsetSet)
 
 static void teds_deque_raise_capacity(teds_deque *intern, const zend_long new_capacity) {
 	const size_t old_capacity = intern->array.capacity;
-	ZEND_ASSERT(new_capacity > old_capacity);
+	ZEND_ASSERT(new_capacity > 0);
+	ZEND_ASSERT((zend_ulong) new_capacity > old_capacity);
 	if (teds_deque_entries_empty_capacity(&intern->array)) {
 		intern->array.circular_buffer = safe_emalloc(new_capacity, sizeof(zval), 0);
 	} else if (intern->array.offset + intern->array.size <= old_capacity) {

--- a/teds_deque.c
+++ b/teds_deque.c
@@ -812,7 +812,7 @@ PHP_METHOD(Teds_Deque, indexOf)
 			RETURN_LONG(i);
 		}
 	}
-	RETURN_FALSE;
+	RETURN_NULL();
 }
 
 PHP_METHOD(Teds_Deque, contains)

--- a/teds_deque.stub.php
+++ b/teds_deque.stub.php
@@ -40,8 +40,8 @@ final class Deque implements \IteratorAggregate, \Countable, \JsonSerializable, 
 
     public function toArray(): array {}
     // Strictly typed, unlike offsetGet/offsetSet
-    public function valueAt(int $offset): mixed {}
-    public function setValueAt(int $offset, mixed $value): void {}
+    public function get(int $offset): mixed {}
+    public function set(int $offset, mixed $value): void {}
     // Must be mixed for compatibility with ArrayAccess
     public function offsetGet(mixed $offset): mixed {}
     public function offsetExists(mixed $offset): bool {}

--- a/teds_deque.stub.php
+++ b/teds_deque.stub.php
@@ -42,7 +42,6 @@ final class Deque implements \IteratorAggregate, \Countable, \JsonSerializable, 
     // Strictly typed, unlike offsetGet/offsetSet
     public function valueAt(int $offset): mixed {}
     public function setValueAt(int $offset, mixed $value): void {}
-    // TODO public function setValueAt(int $offset, mixed $value): mixed {}
     // Must be mixed for compatibility with ArrayAccess
     public function offsetGet(mixed $offset): mixed {}
     public function offsetExists(mixed $offset): bool {}
@@ -50,7 +49,7 @@ final class Deque implements \IteratorAggregate, \Countable, \JsonSerializable, 
     // Throws
     public function offsetUnset(mixed $offset): void {}
 
-    public function indexOf(mixed $value): int|false {}
+    public function indexOf(mixed $value): ?int {}
     public function contains(mixed $value): bool {}
 
     public function jsonSerialize(): array {}

--- a/teds_deque_arginfo.h
+++ b/teds_deque_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cc61dff849bcb4b8e098d404e066fe343369e486 */
+ * Stub hash: f9e35dfb5c7f55365fa3b20e42e7b53cd09d9456 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Deque___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -66,7 +66,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_offsetUnset, 0,
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Teds_Deque_indexOf, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_indexOf, 0, 1, IS_LONG, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 

--- a/teds_deque_arginfo.h
+++ b/teds_deque_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f9e35dfb5c7f55365fa3b20e42e7b53cd09d9456 */
+ * Stub hash: aaf376d4634a100f26b21423e572362d2087f24a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Deque___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -40,11 +40,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_Deque_toArray arginfo_class_Teds_Deque___serialize
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_valueAt, 0, 1, IS_MIXED, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_setValueAt, 0, 2, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_set, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
@@ -90,8 +90,8 @@ ZEND_METHOD(Teds_Deque, pushFront);
 ZEND_METHOD(Teds_Deque, popBack);
 ZEND_METHOD(Teds_Deque, popFront);
 ZEND_METHOD(Teds_Deque, toArray);
-ZEND_METHOD(Teds_Deque, valueAt);
-ZEND_METHOD(Teds_Deque, setValueAt);
+ZEND_METHOD(Teds_Deque, get);
+ZEND_METHOD(Teds_Deque, set);
 ZEND_METHOD(Teds_Deque, offsetGet);
 ZEND_METHOD(Teds_Deque, offsetExists);
 ZEND_METHOD(Teds_Deque, offsetSet);
@@ -115,8 +115,8 @@ static const zend_function_entry class_Teds_Deque_methods[] = {
 	ZEND_ME(Teds_Deque, popBack, arginfo_class_Teds_Deque_popBack, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, popFront, arginfo_class_Teds_Deque_popFront, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, toArray, arginfo_class_Teds_Deque_toArray, ZEND_ACC_PUBLIC)
-	ZEND_ME(Teds_Deque, valueAt, arginfo_class_Teds_Deque_valueAt, ZEND_ACC_PUBLIC)
-	ZEND_ME(Teds_Deque, setValueAt, arginfo_class_Teds_Deque_setValueAt, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_Deque, get, arginfo_class_Teds_Deque_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_Deque, set, arginfo_class_Teds_Deque_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, offsetGet, arginfo_class_Teds_Deque_offsetGet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, offsetExists, arginfo_class_Teds_Deque_offsetExists, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, offsetSet, arginfo_class_Teds_Deque_offsetSet, ZEND_ACC_PUBLIC)

--- a/teds_immutablekeyvaluesequence.c
+++ b/teds_immutablekeyvaluesequence.c
@@ -833,7 +833,7 @@ PHP_METHOD(Teds_ImmutableKeyValueSequence, indexOfKey)
 			RETURN_LONG(i);
 		}
 	}
-	RETURN_FALSE;
+	RETURN_NULL();
 }
 
 PHP_METHOD(Teds_ImmutableKeyValueSequence, indexOfValue)
@@ -851,7 +851,7 @@ PHP_METHOD(Teds_ImmutableKeyValueSequence, indexOfValue)
 			RETURN_LONG(i);
 		}
 	}
-	RETURN_FALSE;
+	RETURN_NULL();
 }
 
 PHP_METHOD(Teds_ImmutableKeyValueSequence, containsKey)

--- a/teds_immutablekeyvaluesequence.c
+++ b/teds_immutablekeyvaluesequence.c
@@ -214,7 +214,9 @@ static void teds_immutablekeyvaluesequence_entries_init_from_traversable(teds_im
  */
 static void teds_immutablekeyvaluesequence_copy_range(teds_immutablekeyvaluesequence_entries *array, size_t offset, zval_pair *begin, zval_pair *end)
 {
-	ZEND_ASSERT(array->size - offset >= end - begin);
+	ZEND_ASSERT(offset <= array->size);
+	ZEND_ASSERT(begin <= end);
+	ZEND_ASSERT(array->size - offset >= (size_t)(end - begin));
 
 	zval_pair *to = &array->entries[offset];
 	while (begin != end) {
@@ -420,7 +422,7 @@ static int teds_immutablekeyvaluesequence_it_valid(zend_object_iterator *iter)
 	teds_immutablekeyvaluesequence_it     *iterator = (teds_immutablekeyvaluesequence_it*)iter;
 	teds_immutablekeyvaluesequence *object   = Z_IMMUTABLEKEYVALUESEQUENCE_P(&iter->data);
 
-	if (iterator->current >= 0 && iterator->current < object->array.size) {
+	if (iterator->current >= 0 && ((zend_ulong) iterator->current) < object->array.size) {
 		return SUCCESS;
 	}
 

--- a/teds_immutablekeyvaluesequence.stub.php
+++ b/teds_immutablekeyvaluesequence.stub.php
@@ -25,8 +25,8 @@ final class ImmutableKeyValueSequence implements \IteratorAggregate, \Countable,
     public function keyAt(int $offset): mixed {}
     public function valueAt(int $offset): mixed {}
 
-    public function indexOfKey(mixed $key): int|false {}
-    public function indexOfValue(mixed $value): int|false {}
+    public function indexOfKey(mixed $key): ?int {}
+    public function indexOfValue(mixed $value): ?int {}
     public function containsKey(mixed $key): bool {}
     public function containsValue(mixed $value): bool {}
 

--- a/teds_immutablekeyvaluesequence_arginfo.h
+++ b/teds_immutablekeyvaluesequence_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 57932b5044c391619cbc5d3070e30c1e0e0db542 */
+ * Stub hash: bec125d04a807a0665d574627653af07be131e08 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_ImmutableKeyValueSequence___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, iterator, IS_ITERABLE, 0)
@@ -38,11 +38,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_ImmutableKeyValueSequence_valueAt arginfo_class_Teds_ImmutableKeyValueSequence_keyAt
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Teds_ImmutableKeyValueSequence_indexOfKey, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableKeyValueSequence_indexOfKey, 0, 1, IS_LONG, 1)
 	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Teds_ImmutableKeyValueSequence_indexOfValue, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableKeyValueSequence_indexOfValue, 0, 1, IS_LONG, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 

--- a/teds_immutablesequence.c
+++ b/teds_immutablesequence.c
@@ -189,7 +189,9 @@ static void teds_cached_entries_init_from_traversable(teds_cached_entries *array
  */
 static void teds_immutablesequence_copy_range(teds_cached_entries *array, size_t offset, zval *begin, zval *end)
 {
-	ZEND_ASSERT(array->size - offset >= end - begin);
+	ZEND_ASSERT(offset <= array->size);
+	ZEND_ASSERT(begin <= end);
+	ZEND_ASSERT(array->size - offset >= (size_t)(end - begin));
 
 	zval *to = &array->entries[offset];
 	while (begin != end) {
@@ -390,7 +392,7 @@ static int teds_immutablesequence_it_valid(zend_object_iterator *iter)
 	teds_immutablesequence_it     *iterator = (teds_immutablesequence_it*)iter;
 	teds_immutablesequence_object *object   = Z_IMMUTABLESEQUENCE_P(&iter->data);
 
-	if (iterator->current >= 0 && iterator->current < object->array.size) {
+	if (iterator->current >= 0 && ((zend_ulong) iterator->current) < object->array.size) {
 		return SUCCESS;
 	}
 
@@ -616,7 +618,7 @@ static zend_always_inline void teds_immutablesequence_get_value_at_offset(zval *
 	RETURN_COPY(&intern->array.entries[offset]);
 }
 
-PHP_METHOD(Teds_ImmutableSequence, valueAt)
+PHP_METHOD(Teds_ImmutableSequence, get)
 {
 	zend_long offset;
 	ZEND_PARSE_PARAMETERS_START(1, 1)

--- a/teds_immutablesequence.c
+++ b/teds_immutablesequence.c
@@ -654,7 +654,7 @@ PHP_METHOD(Teds_ImmutableSequence, indexOf)
 			RETURN_LONG(i);
 		}
 	}
-	RETURN_FALSE;
+	RETURN_NULL();
 }
 
 PHP_METHOD(Teds_ImmutableSequence, contains)

--- a/teds_immutablesequence.stub.php
+++ b/teds_immutablesequence.stub.php
@@ -17,7 +17,7 @@ final class ImmutableSequence implements \IteratorAggregate, \Countable, \JsonSe
 
     public function toArray(): array {}
     // Strictly typed, unlike offsetGet
-    public function valueAt(int $offset): mixed {}
+    public function get(int $offset): mixed {}
     // Must be mixed for compatibility with ArrayAccess
     public function offsetGet(mixed $offset): mixed {}
     public function offsetExists(mixed $offset): bool {}

--- a/teds_immutablesequence.stub.php
+++ b/teds_immutablesequence.stub.php
@@ -26,7 +26,7 @@ final class ImmutableSequence implements \IteratorAggregate, \Countable, \JsonSe
     // Throws
     public function offsetUnset(mixed $offset): void {}
 
-    public function indexOf(mixed $value): int|false {}
+    public function indexOf(mixed $value): ?int {}
     public function contains(mixed $value): bool {}
 
     public function jsonSerialize(): array {}

--- a/teds_immutablesequence_arginfo.h
+++ b/teds_immutablesequence_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: aa3d1da43720da483ea072ed818bb3d74f6ea2d7 */
+ * Stub hash: dac0f2f4aace15310101357a28cf08fa517b4804 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_ImmutableSequence___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, iterator, IS_ITERABLE, 0)
@@ -45,7 +45,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableSequence_off
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Teds_ImmutableSequence_indexOf, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableSequence_indexOf, 0, 1, IS_LONG, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 

--- a/teds_immutablesequence_arginfo.h
+++ b/teds_immutablesequence_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dac0f2f4aace15310101357a28cf08fa517b4804 */
+ * Stub hash: b2f8eaddc435b4a36746d9c503c300fcc5247d0e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_ImmutableSequence___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, iterator, IS_ITERABLE, 0)
@@ -24,7 +24,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_ImmutableSequence_toArray arginfo_class_Teds_ImmutableSequence___serialize
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableSequence_valueAt, 0, 1, IS_MIXED, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableSequence_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -63,7 +63,7 @@ ZEND_METHOD(Teds_ImmutableSequence, __serialize);
 ZEND_METHOD(Teds_ImmutableSequence, __unserialize);
 ZEND_METHOD(Teds_ImmutableSequence, __set_state);
 ZEND_METHOD(Teds_ImmutableSequence, toArray);
-ZEND_METHOD(Teds_ImmutableSequence, valueAt);
+ZEND_METHOD(Teds_ImmutableSequence, get);
 ZEND_METHOD(Teds_ImmutableSequence, offsetGet);
 ZEND_METHOD(Teds_ImmutableSequence, offsetExists);
 ZEND_METHOD(Teds_ImmutableSequence, offsetSet);
@@ -81,7 +81,7 @@ static const zend_function_entry class_Teds_ImmutableSequence_methods[] = {
 	ZEND_ME(Teds_ImmutableSequence, __unserialize, arginfo_class_Teds_ImmutableSequence___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, __set_state, arginfo_class_Teds_ImmutableSequence___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Teds_ImmutableSequence, toArray, arginfo_class_Teds_ImmutableSequence_toArray, ZEND_ACC_PUBLIC)
-	ZEND_ME(Teds_ImmutableSequence, valueAt, arginfo_class_Teds_ImmutableSequence_valueAt, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_ImmutableSequence, get, arginfo_class_Teds_ImmutableSequence_get, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, offsetGet, arginfo_class_Teds_ImmutableSequence_offsetGet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, offsetExists, arginfo_class_Teds_ImmutableSequence_offsetExists, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, offsetSet, arginfo_class_Teds_ImmutableSequence_offsetSet, ZEND_ACC_PUBLIC)

--- a/teds_keyvaluevector.c
+++ b/teds_keyvaluevector.c
@@ -979,7 +979,7 @@ PHP_METHOD(Teds_KeyValueVector, indexOfKey)
 			RETURN_LONG(i);
 		}
 	}
-	RETURN_FALSE;
+	RETURN_NULL();
 }
 
 PHP_METHOD(Teds_KeyValueVector, indexOfValue)
@@ -997,7 +997,7 @@ PHP_METHOD(Teds_KeyValueVector, indexOfValue)
 			RETURN_LONG(i);
 		}
 	}
-	RETURN_FALSE;
+	RETURN_NULL();
 }
 
 PHP_METHOD(Teds_KeyValueVector, containsKey)

--- a/teds_keyvaluevector.stub.php
+++ b/teds_keyvaluevector.stub.php
@@ -33,8 +33,8 @@ final class KeyValueVector implements \IteratorAggregate, \Countable, \JsonSeria
     public function setKeyAt(int $offset, mixed $key): void {}
     public function setValueAt(int $offset, mixed $value): void {}
 
-    public function indexOfKey(mixed $key): int|false {}
-    public function indexOfValue(mixed $value): int|false {}
+    public function indexOfKey(mixed $key): ?int {}
+    public function indexOfValue(mixed $value): ?int {}
     public function containsKey(mixed $key): bool {}
     public function containsValue(mixed $value): bool {}
 

--- a/teds_keyvaluevector_arginfo.h
+++ b/teds_keyvaluevector_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6c0ad01d61df9fa35a4349db13c953bd9bb3808e */
+ * Stub hash: 0fadc5f6d60368a247797b694f35deb522e4319a */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_KeyValueVector___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -64,11 +64,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_KeyValueVector_setVal
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Teds_KeyValueVector_indexOfKey, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_KeyValueVector_indexOfKey, 0, 1, IS_LONG, 1)
 	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Teds_KeyValueVector_indexOfValue, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_KeyValueVector_indexOfValue, 0, 1, IS_LONG, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 

--- a/teds_vector.stub.php
+++ b/teds_vector.stub.php
@@ -15,11 +15,33 @@ final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable,
      */
     public function __construct(iterable $iterator = [], bool $preserveKeys = true) {}
     public function getIterator(): \InternalIterator {}
+    /**
+     * Returns the number of values in this Vector
+     */
     public function count(): int {}
+    /**
+     * Returns the total capacity of this Vector.
+     */
     public function capacity(): int {}
+    /**
+     * Reduces the Vector's capacity to its size, freeing any extra unused memory.
+     */
     public function shrinkToFit(): void {}
+    /**
+     * If the current capacity is less than $capacity, raise it to capacity.
+     * @throws UnexpectedValueException if the new capacity is too large
+     */
+    public function reserve(int $capacity): void {}
+    /**
+     * Remove all elements from the array and free all reserved capacity.
+     */
     public function clear(): void {}
-    public function setSize(int $size): void {}
+
+    /**
+     * If $size is greater than the current size, raise the size and fill the free space with $value
+     * If $size is less than the current size, reduce the size and discard elements.
+     */
+    public function setSize(int $size, mixed $value = null): void {}
 
     public function __serialize(): array {}
     public function __unserialize(array $data): void {}
@@ -33,15 +55,41 @@ final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable,
     public function valueAt(int $offset): mixed {}
     public function setValueAt(int $offset, mixed $value): void {}
 
+    /**
+     * Returns the value at (int)$offset.
+     * @throws \OutOfBoundsException if the value of (int)$offset is not within the bounds of this vector
+     */
     public function offsetGet(mixed $offset): mixed {}
+    /**
+     * Returns true if `0 <= (int)$offset && (int)$offset < $this->count().
+     */
     public function offsetExists(mixed $offset): bool {}
+
+    /**
+     * @throws \OutOfBoundsException if the value of (int)$offset is not within the bounds of this vector
+     */
     public function offsetSet(mixed $offset, mixed $value): void {}
-    // Throws because unset and null are different things, unlike SplFixedArray
+
+    /**
+     * @throws \RuntimeException because unset and null are different things, unlike SplFixedArray
+     */
     public function offsetUnset(mixed $offset): void {}
 
-    public function indexOf(mixed $value): int|false {}
+    /**
+     * Returns the offset of a value that is === $value, or returns null.
+     */
+    public function indexOf(mixed $value): ?int {}
+    /**
+     * @return bool true if there exists a value === $value in this vector.
+     */
     public function contains(mixed $value): bool {}
 
+    /**
+     * Returns a new Vector instance created from the return values of $callable($element)
+     * being applied to each element of this vector.
+     *
+     * (at)param null|callable(mixed):mixed $callback
+     */
     public function map(callable $callback): Vector {}
     /**
      * Returns the subset of elements of the Vector satisfying the predicate.
@@ -50,7 +98,7 @@ final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable,
      * (e.g. true, non-zero number, non-empty array, truthy object, etc.),
      * this is treated as satisfying the predicate.
      *
-     * (at)param null|callable(mixed):mixed $callback
+     * (at)param null|callable(mixed):bool $callback
      */
     public function filter(?callable $callback = null): Vector {}
 

--- a/teds_vector.stub.php
+++ b/teds_vector.stub.php
@@ -52,8 +52,8 @@ final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable,
 
     public function toArray(): array {}
     // Strictly typed, unlike offsetGet/offsetSet
-    public function valueAt(int $offset): mixed {}
-    public function setValueAt(int $offset, mixed $value): void {}
+    public function get(int $offset): mixed {}
+    public function set(int $offset, mixed $value): void {}
 
     /**
      * Returns the value at (int)$offset.

--- a/teds_vector_arginfo.h
+++ b/teds_vector_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3ad8b294d6f44d056665ec3e33ad4440d4b92ea3 */
+ * Stub hash: ada5aee0889a7274a912c872ba674bb7053a89b7 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Vector___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -48,11 +48,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_Vector_toArray arginfo_class_Teds_Vector___serialize
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_valueAt, 0, 1, IS_MIXED, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_setValueAt, 0, 2, IS_VOID, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_set, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
@@ -107,8 +107,8 @@ ZEND_METHOD(Teds_Vector, __set_state);
 ZEND_METHOD(Teds_Vector, push);
 ZEND_METHOD(Teds_Vector, pop);
 ZEND_METHOD(Teds_Vector, toArray);
-ZEND_METHOD(Teds_Vector, valueAt);
-ZEND_METHOD(Teds_Vector, setValueAt);
+ZEND_METHOD(Teds_Vector, get);
+ZEND_METHOD(Teds_Vector, set);
 ZEND_METHOD(Teds_Vector, offsetGet);
 ZEND_METHOD(Teds_Vector, offsetExists);
 ZEND_METHOD(Teds_Vector, offsetSet);
@@ -135,8 +135,8 @@ static const zend_function_entry class_Teds_Vector_methods[] = {
 	ZEND_ME(Teds_Vector, push, arginfo_class_Teds_Vector_push, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, pop, arginfo_class_Teds_Vector_pop, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, toArray, arginfo_class_Teds_Vector_toArray, ZEND_ACC_PUBLIC)
-	ZEND_ME(Teds_Vector, valueAt, arginfo_class_Teds_Vector_valueAt, ZEND_ACC_PUBLIC)
-	ZEND_ME(Teds_Vector, setValueAt, arginfo_class_Teds_Vector_setValueAt, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_Vector, get, arginfo_class_Teds_Vector_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_Vector, set, arginfo_class_Teds_Vector_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, offsetGet, arginfo_class_Teds_Vector_offsetGet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, offsetExists, arginfo_class_Teds_Vector_offsetExists, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, offsetSet, arginfo_class_Teds_Vector_offsetSet, ZEND_ACC_PUBLIC)

--- a/teds_vector_arginfo.h
+++ b/teds_vector_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4450b815163ae7a373d6da59c553fd3f9dd6c294 */
+ * Stub hash: 3ad8b294d6f44d056665ec3e33ad4440d4b92ea3 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Vector___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -17,10 +17,15 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_shrinkToFit, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_reserve, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, capacity, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_Teds_Vector_clear arginfo_class_Teds_Vector_shrinkToFit
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_setSize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, size, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, value, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector___serialize, 0, 0, IS_ARRAY, 0)
@@ -69,7 +74,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_offsetUnset, 0
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Teds_Vector_indexOf, 0, 1, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_indexOf, 0, 1, IS_LONG, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
@@ -93,6 +98,7 @@ ZEND_METHOD(Teds_Vector, getIterator);
 ZEND_METHOD(Teds_Vector, count);
 ZEND_METHOD(Teds_Vector, capacity);
 ZEND_METHOD(Teds_Vector, shrinkToFit);
+ZEND_METHOD(Teds_Vector, reserve);
 ZEND_METHOD(Teds_Vector, clear);
 ZEND_METHOD(Teds_Vector, setSize);
 ZEND_METHOD(Teds_Vector, __serialize);
@@ -120,6 +126,7 @@ static const zend_function_entry class_Teds_Vector_methods[] = {
 	ZEND_ME(Teds_Vector, count, arginfo_class_Teds_Vector_count, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, capacity, arginfo_class_Teds_Vector_capacity, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, shrinkToFit, arginfo_class_Teds_Vector_shrinkToFit, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_Vector, reserve, arginfo_class_Teds_Vector_reserve, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, clear, arginfo_class_Teds_Vector_clear, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, setSize, arginfo_class_Teds_Vector_setSize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, __serialize, arginfo_class_Teds_Vector___serialize, ZEND_ACC_PUBLIC)

--- a/tests/Deque/contains.phpt
+++ b/tests/Deque/contains.phpt
@@ -10,8 +10,8 @@ foreach ([null, 'o', $o, new stdClass(), strtolower('FIRST')] as $value) {
 }
 ?>
 --EXPECT--
-null: contains=false, indexOf=false
-"o": contains=false, indexOf=false
+null: contains=false, indexOf=null
+"o": contains=false, indexOf=null
 {}: contains=true, indexOf=1
-{}: contains=false, indexOf=false
+{}: contains=false, indexOf=null
 "first": contains=true, indexOf=0

--- a/tests/Deque/offsetGet.phpt
+++ b/tests/Deque/offsetGet.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Teds\Deque offsetGet/valueAt
+Teds\Deque offsetGet/get
 --FILE--
 <?php
 
@@ -14,7 +14,7 @@ function expect_throws(Closure $cb): void {
 expect_throws(fn() => (new ReflectionClass(Teds\Deque::class))->newInstanceWithoutConstructor());
 $it = new Teds\Deque(['first' => new stdClass()]);
 var_dump($it->offsetGet(0));
-var_dump($it->valueAt(0));
+var_dump($it->get(0));
 expect_throws(fn() => $it->offsetSet(1,'x'));
 expect_throws(fn() => $it->offsetUnset(0));
 var_dump($it->offsetGet('0'));
@@ -23,20 +23,20 @@ var_dump($it->offsetExists(1));
 var_dump($it->offsetExists('1'));
 var_dump($it->offsetExists(PHP_INT_MAX));
 var_dump($it->offsetExists(PHP_INT_MIN));
-expect_throws(fn() => $it->valueAt(1));
-expect_throws(fn() => $it->valueAt(-1));
+expect_throws(fn() => $it->get(1));
+expect_throws(fn() => $it->get(-1));
 echo "Invalid offsetGet calls\n";
 expect_throws(fn() => $it->offsetGet(PHP_INT_MAX));
 expect_throws(fn() => $it->offsetGet(PHP_INT_MIN));
 expect_throws(fn() => $it->offsetGet(1));
-expect_throws(fn() => $it->valueAt(PHP_INT_MAX));
-expect_throws(fn() => $it->valueAt(PHP_INT_MIN));
-expect_throws(fn() => $it->valueAt(1));
-expect_throws(fn() => $it->valueAt(-1));
+expect_throws(fn() => $it->get(PHP_INT_MAX));
+expect_throws(fn() => $it->get(PHP_INT_MIN));
+expect_throws(fn() => $it->get(1));
+expect_throws(fn() => $it->get(-1));
 expect_throws(fn() => $it->offsetGet(1));
 expect_throws(fn() => $it->offsetGet('1'));
 expect_throws(fn() => $it->offsetGet('invalid'));
-expect_throws(fn() => $it->valueAt('invalid'));
+expect_throws(fn() => $it->get('invalid'));
 expect_throws(fn() => $it[['invalid']]);
 expect_throws(fn() => $it->offsetUnset(PHP_INT_MAX));
 expect_throws(fn() => $it->offsetSet(PHP_INT_MAX,'x'));
@@ -71,7 +71,7 @@ Caught OutOfBoundsException: Index out of range
 Caught OutOfBoundsException: Index out of range
 Caught OutOfBoundsException: Index out of range
 Caught TypeError: Illegal offset type string
-Caught TypeError: Teds\Deque::valueAt(): Argument #1 ($offset) must be of type int, string given
+Caught TypeError: Teds\Deque::get(): Argument #1 ($offset) must be of type int, string given
 Caught TypeError: Illegal offset type array
 Caught RuntimeException: Teds\Deque does not support offsetUnset - elements must be set to null or removed by resizing
 Caught OutOfBoundsException: Index out of range

--- a/tests/Deque/setValueAt.phpt
+++ b/tests/Deque/setValueAt.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Teds\Deque offsetSet/setValueAt
+Teds\Deque offsetSet/set
 --FILE--
 <?php
 
@@ -15,17 +15,17 @@ function expect_throws(Closure $cb): void {
 echo "Test empty deque\n";
 $it = new Teds\Deque([]);
 expect_throws(fn() => $it->offsetSet(0, strtoupper('value')));
-expect_throws(fn() => $it->setValueAt(0, strtoupper('value')));
+expect_throws(fn() => $it->set(0, strtoupper('value')));
 
 echo "Test short deque\n";
 $str = 'Test short deque';
 $it = new Teds\Deque(explode(' ', $str));
-$it->setValueAt(0, 'new');
+$it->set(0, 'new');
 $it->offsetSet(2, strtoupper('test'));
 echo json_encode($it), "\n";
-expect_throws(fn() => $it->setValueAt(-1, strtoupper('value')));
-expect_throws(fn() => $it->setValueAt(3, 'end'));
-expect_throws(fn() => $it->setValueAt(PHP_INT_MAX, 'end'));
+expect_throws(fn() => $it->set(-1, strtoupper('value')));
+expect_throws(fn() => $it->set(3, 'end'));
+expect_throws(fn() => $it->set(PHP_INT_MAX, 'end'));
 
 ?>
 --EXPECT--

--- a/tests/ImmutableKeyValueSequence/contains.phpt
+++ b/tests/ImmutableKeyValueSequence/contains.phpt
@@ -13,11 +13,11 @@ foreach ([0, 1, strtolower('FIRST')] as $key) {
 }
 ?>
 --EXPECT--
-null: containsValue=false, indexOfValue=false
-"o": containsValue=false, indexOfValue=false
+null: containsValue=false, indexOfValue=null
+"o": containsValue=false, indexOfValue=null
 {}: containsValue=true, indexOfValue=1
-{}: containsValue=false, indexOfValue=false
+{}: containsValue=false, indexOfValue=null
 "first": containsValue=true, indexOfValue=0
 0: containsKey=true, indexOfKey=0
 1: containsKey=true, indexOfKey=1
-"first": containsKey=false, indexOfKey=false
+"first": containsKey=false, indexOfKey=null

--- a/tests/ImmutableSequence/contains.phpt
+++ b/tests/ImmutableSequence/contains.phpt
@@ -10,8 +10,8 @@ foreach ([null, 'o', $o, new stdClass(), strtolower('FIRST')] as $value) {
 }
 ?>
 --EXPECT--
-null: contains=false, indexOf=false
-"o": contains=false, indexOf=false
+null: contains=false, indexOf=null
+"o": contains=false, indexOf=null
 {}: contains=true, indexOf=1
-{}: contains=false, indexOf=false
+{}: contains=false, indexOf=null
 "first": contains=true, indexOf=0

--- a/tests/ImmutableSequence/offsetGet.phpt
+++ b/tests/ImmutableSequence/offsetGet.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Teds\ImmutableSequence offsetGet/valueAt
+Teds\ImmutableSequence offsetGet/get
 --FILE--
 <?php
 
@@ -14,7 +14,7 @@ function expect_throws(Closure $cb): void {
 expect_throws(fn() => (new ReflectionClass(Teds\ImmutableSequence::class))->newInstanceWithoutConstructor());
 $it = new Teds\ImmutableSequence(['first' => new stdClass()]);
 var_dump($it->offsetGet(0));
-var_dump($it->valueAt(0));
+var_dump($it->get(0));
 expect_throws(fn() => $it->offsetSet(0,'x'));
 expect_throws(fn() => $it->offsetUnset(0));
 var_dump($it->offsetGet('0'));
@@ -23,20 +23,20 @@ var_dump($it->offsetExists(1));
 var_dump($it->offsetExists('1'));
 var_dump($it->offsetExists(PHP_INT_MAX));
 var_dump($it->offsetExists(PHP_INT_MIN));
-expect_throws(fn() => $it->valueAt(1));
-expect_throws(fn() => $it->valueAt(-1));
+expect_throws(fn() => $it->get(1));
+expect_throws(fn() => $it->get(-1));
 echo "Invalid offsetGet calls\n";
 expect_throws(fn() => $it->offsetGet(PHP_INT_MAX));
 expect_throws(fn() => $it->offsetGet(PHP_INT_MIN));
 expect_throws(fn() => $it->offsetGet(1));
-expect_throws(fn() => $it->valueAt(PHP_INT_MAX));
-expect_throws(fn() => $it->valueAt(PHP_INT_MIN));
-expect_throws(fn() => $it->valueAt(1));
-expect_throws(fn() => $it->valueAt(-1));
+expect_throws(fn() => $it->get(PHP_INT_MAX));
+expect_throws(fn() => $it->get(PHP_INT_MIN));
+expect_throws(fn() => $it->get(1));
+expect_throws(fn() => $it->get(-1));
 expect_throws(fn() => $it->offsetGet(1));
 expect_throws(fn() => $it->offsetGet('1'));
 expect_throws(fn() => $it->offsetGet('invalid'));
-expect_throws(fn() => $it->valueAt('invalid'));
+expect_throws(fn() => $it->get('invalid'));
 expect_throws(fn() => $it[['invalid']]);
 expect_throws(fn() => $it->offsetUnset(PHP_INT_MAX));
 expect_throws(fn() => $it->offsetSet(PHP_INT_MAX,'x'));
@@ -71,7 +71,7 @@ Caught OutOfBoundsException: Index out of range
 Caught OutOfBoundsException: Index out of range
 Caught OutOfBoundsException: Index out of range
 Caught TypeError: Illegal offset type string
-Caught TypeError: Teds\ImmutableSequence::valueAt(): Argument #1 ($offset) must be of type int, string given
+Caught TypeError: Teds\ImmutableSequence::get(): Argument #1 ($offset) must be of type int, string given
 Caught TypeError: Illegal offset type array
 Caught RuntimeException: ImmutableSequence does not support offsetUnset - it is immutable
 Caught RuntimeException: ImmutableSequence does not support offsetSet - it is immutable

--- a/tests/KeyValueVector/contains.phpt
+++ b/tests/KeyValueVector/contains.phpt
@@ -13,11 +13,11 @@ foreach ([0, 1, strtolower('FIRST')] as $key) {
 }
 ?>
 --EXPECT--
-null: containsValue=false, indexOfValue=false
-"o": containsValue=false, indexOfValue=false
+null: containsValue=false, indexOfValue=null
+"o": containsValue=false, indexOfValue=null
 {}: containsValue=true, indexOfValue=1
-{}: containsValue=false, indexOfValue=false
+{}: containsValue=false, indexOfValue=null
 "first": containsValue=true, indexOfValue=0
 0: containsKey=true, indexOfKey=0
 1: containsKey=true, indexOfKey=1
-"first": containsKey=false, indexOfKey=false
+"first": containsKey=false, indexOfKey=null

--- a/tests/Vector/contains.phpt
+++ b/tests/Vector/contains.phpt
@@ -10,8 +10,8 @@ foreach ([null, 'o', $o, new stdClass(), strtolower('FIRST')] as $value) {
 }
 ?>
 --EXPECT--
-null: contains=false, indexOf=false
-"o": contains=false, indexOf=false
+null: contains=false, indexOf=null
+"o": contains=false, indexOf=null
 {}: contains=true, indexOf=1
-{}: contains=false, indexOf=false
+{}: contains=false, indexOf=null
 "first": contains=true, indexOf=0

--- a/tests/Vector/offsetGet.phpt
+++ b/tests/Vector/offsetGet.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Teds\Vector offsetGet/valueAt
+Teds\Vector offsetGet/get
 --FILE--
 <?php
 
@@ -14,7 +14,7 @@ function expect_throws(Closure $cb): void {
 expect_throws(fn() => (new ReflectionClass(Teds\Vector::class))->newInstanceWithoutConstructor());
 $it = new Teds\Vector([new stdClass()]);
 var_dump($it->offsetGet(0));
-var_dump($it->valueAt(0));
+var_dump($it->get(0));
 expect_throws(fn() => $it->offsetSet(1,'x'));
 expect_throws(fn() => $it->offsetUnset(0));
 var_dump($it->offsetGet('0'));
@@ -23,20 +23,20 @@ var_dump($it->offsetExists(1));
 var_dump($it->offsetExists('1'));
 var_dump($it->offsetExists(PHP_INT_MAX));
 var_dump($it->offsetExists(PHP_INT_MIN));
-expect_throws(fn() => $it->valueAt(1));
-expect_throws(fn() => $it->valueAt(-1));
+expect_throws(fn() => $it->get(1));
+expect_throws(fn() => $it->get(-1));
 echo "Invalid offsetGet calls\n";
 expect_throws(fn() => $it->offsetGet(PHP_INT_MAX));
 expect_throws(fn() => $it->offsetGet(PHP_INT_MIN));
 expect_throws(fn() => $it->offsetGet(1));
-expect_throws(fn() => $it->valueAt(PHP_INT_MAX));
-expect_throws(fn() => $it->valueAt(PHP_INT_MIN));
-expect_throws(fn() => $it->valueAt(1));
-expect_throws(fn() => $it->valueAt(-1));
+expect_throws(fn() => $it->get(PHP_INT_MAX));
+expect_throws(fn() => $it->get(PHP_INT_MIN));
+expect_throws(fn() => $it->get(1));
+expect_throws(fn() => $it->get(-1));
 expect_throws(fn() => $it->offsetGet(1));
 expect_throws(fn() => $it->offsetGet('1'));
 expect_throws(fn() => $it->offsetGet('invalid'));
-expect_throws(fn() => $it->valueAt('invalid'));
+expect_throws(fn() => $it->get('invalid'));
 expect_throws(fn() => $it[['invalid']]);
 expect_throws(fn() => $it->offsetUnset(PHP_INT_MAX));
 expect_throws(fn() => $it->offsetSet(PHP_INT_MAX,'x'));
@@ -71,7 +71,7 @@ Caught OutOfBoundsException: Index out of range
 Caught OutOfBoundsException: Index out of range
 Caught OutOfBoundsException: Index out of range
 Caught TypeError: Illegal offset type string
-Caught TypeError: Teds\Vector::valueAt(): Argument #1 ($offset) must be of type int, string given
+Caught TypeError: Teds\Vector::get(): Argument #1 ($offset) must be of type int, string given
 Caught TypeError: Illegal offset type array
 Caught RuntimeException: Teds\Vector does not support offsetUnset - elements must be set to null or removed by resizing
 Caught OutOfBoundsException: Index out of range

--- a/tests/Vector/reserve.phpt
+++ b/tests/Vector/reserve.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Teds\Vector reserve()
+--FILE--
+<?php
+$it = new Teds\Vector();
+$it->reserve(2);
+printf("values=%s count=%d capacity=%d\n", json_encode($it), $it->count(), $it->capacity());
+$it[] = strtoupper('first');
+$it[] = 'second';
+printf("values=%s count=%d capacity=%d\n", json_encode($it), $it->count(), $it->capacity());
+$it->reserve(3);
+printf("capacity=%d\n", $it->capacity());
+$it[] = 'extra';
+printf("values=%s count=%d capacity=%d\n", json_encode($it), $it->count(), $it->capacity());
+// reserve does nothing if the capacity is already greater than the requested capacity
+$it->reserve(3);
+$it->reserve(1);
+$it->reserve(0);
+$it->reserve(PHP_INT_MIN);
+printf("unchanged values=%s count=%d capacity=%d\n", json_encode($it), $it->count(), $it->capacity());
+try {
+    $it->reserve(PHP_INT_MAX);
+} catch (UnexpectedValueException $e) {
+    printf("Caught: %s\n", $e->getMessage());
+}
+printf("unchanged values=%s count=%d capacity=%d\n", json_encode($it), $it->count(), $it->capacity());
+?>
+--EXPECT--
+values=[] count=0 capacity=2
+values=["FIRST","second"] count=2 capacity=2
+capacity=3
+values=["FIRST","second","extra"] count=3 capacity=3
+unchanged values=["FIRST","second","extra"] count=3 capacity=3
+Caught: exceeded max valid offset
+unchanged values=["FIRST","second","extra"] count=3 capacity=3

--- a/tests/Vector/setSize_default.phpt
+++ b/tests/Vector/setSize_default.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Teds\Vector setSize with $default
+--FILE--
+<?php
+function show(Teds\Vector $it) {
+    printf("value=%s count=%d capacity=%d\n", json_encode($it), $it->count(), $it->capacity());
+}
+
+$it = new Teds\Vector();
+show($it);
+$it->setSize(2, 0);
+$it[0] = new stdClass();
+$it->setSize(3, null);
+show($it);
+$it->setSize(0, new stdClass());
+show($it);
+$it->setSize(5, strtoupper('na'));
+show($it);
+?>
+--EXPECT--
+value=[] count=0 capacity=0
+value=[{},0,null] count=3 capacity=3
+value=[] count=0 capacity=0
+value=["NA","NA","NA","NA","NA"] count=5 capacity=5

--- a/tests/Vector/setValueAt.phpt
+++ b/tests/Vector/setValueAt.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Teds\Vector offsetSet/setValueAt
+Teds\Vector offsetSet/set
 --FILE--
 <?php
 
@@ -15,17 +15,17 @@ function expect_throws(Closure $cb): void {
 echo "Test empty vector\n";
 $it = new Teds\Vector([]);
 expect_throws(fn() => $it->offsetSet(0, strtoupper('value')));
-expect_throws(fn() => $it->setValueAt(0, strtoupper('value')));
+expect_throws(fn() => $it->set(0, strtoupper('value')));
 
 echo "Test short vector\n";
 $str = 'Test short vector';
 $it = new Teds\Vector(explode(' ', $str));
-$it->setValueAt(0, 'new');
+$it->set(0, 'new');
 $it->offsetSet(2, strtoupper('test'));
 echo json_encode($it), "\n";
-expect_throws(fn() => $it->setValueAt(-1, strtoupper('value')));
-expect_throws(fn() => $it->setValueAt(3, 'end'));
-expect_throws(fn() => $it->setValueAt(PHP_INT_MAX, 'end'));
+expect_throws(fn() => $it->set(-1, strtoupper('value')));
+expect_throws(fn() => $it->set(3, 'end'));
+expect_throws(fn() => $it->set(PHP_INT_MAX, 'end'));
 
 ?>
 --EXPECT--


### PR DESCRIPTION
Make all `indexOf*` methods return `?int` everywhere, not `int|false`

Add `$value=null` to choose padding when extending an array in setSize
Add Vector::reserve to raise Vector capacity.