### PR TITLE
Automatically reclaim unused capacity in Deque

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
 * Add optional parameter `$value = null` to `Vector::setSize()` to allow overriding the value used for padding when lengthening an array.
 * Change exception handling for sizes/capacities that are definitely too large to allocate.
 * Make Vector::push() variadic and accept 0 or more arguments, like `array_push` does.
+* Reclaim unused memory in Deque when roughly a quarter or less of the internal buffer is used.
  </notes>
  <contents>
   <dir name="/">
@@ -71,6 +72,8 @@
     <file name="Deque/iterator.phpt" role="test" />
     <file name="Deque/offsetGet.phpt" role="test" />
     <file name="Deque/popFront.phpt" role="test" />
+    <file name="Deque/popMany.phpt" role="test" />
+    <file name="Deque/pushFront.phpt" role="test" />
     <file name="Deque/push_pop.phpt" role="test" />
     <file name="Deque/push_pop_both.phpt" role="test" />
     <file name="Deque/reinit_forbidden.phpt" role="test" />

--- a/tests/Deque/popMany.phpt
+++ b/tests/Deque/popMany.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Teds\Deque push repeatedly
+--FILE--
+<?php
+
+$dq = new Teds\Deque();
+for ($i = 0; $i < 8; $i++) {
+    $dq->pushBack("v$i");
+}
+$dq->popFront();
+$dq->pushBack("extra");
+printf("dq=%s count=%d capacity=%d\n", json_encode($dq), $dq->count(), $dq->capacity());
+for ($i = 0; $i < 7; $i++) {
+    $value = $dq->popFront();
+    printf("popped %s capacity=%d\n", $value, $dq->capacity());
+}
+// Deque should reclaim memory once roughly a quarter of the memory is actually used.
+printf("dq=%s count=%d capacity=%d\n", json_encode($dq), $dq->count(), $dq->capacity());
+var_dump($dq);
+$dq->clear();
+printf("dq=%s count=%d capacity=%d\n", json_encode($dq), $dq->count(), $dq->capacity());
+var_dump($dq);
+?>
+--EXPECT--
+dq=["v1","v2","v3","v4","v5","v6","v7","extra"] count=8 capacity=8
+popped v1 capacity=8
+popped v2 capacity=8
+popped v3 capacity=8
+popped v4 capacity=8
+popped v5 capacity=8
+popped v6 capacity=8
+popped v7 capacity=4
+dq=["extra"] count=1 capacity=4
+object(Teds\Deque)#1 (1) {
+  [0]=>
+  string(5) "extra"
+}
+dq=[] count=0 capacity=0
+object(Teds\Deque)#1 (0) {
+}

--- a/tests/Deque/pushFront.phpt
+++ b/tests/Deque/pushFront.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Teds\Deque pushFront
+--FILE--
+<?php
+
+$it = new Teds\Deque();
+for ($i = 0; $i < 20; $i++) {
+    $it->pushFront("$i");
+}
+foreach ($it as $value) {
+    echo "$value,";
+}
+echo "\n";
+$values = [];
+while (count($it) > 0) {
+    $values[] = $it->popFront();
+}
+echo json_encode($values), "\n";
+?>
+--EXPECT--
+19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0,
+["19","18","17","16","15","14","13","12","11","10","9","8","7","6","5","4","3","2","1","0"]


### PR DESCRIPTION
When roughly a quarter of the size is used, reduce the Deque size while still
leaving some room for additions

Closes #28