### PR TITLE
Make Deque iteration account for calls to push/pop

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,22 +36,22 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.1.0RC1
+                  PHP_VER: 8.1.1
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.1.0RC1
+                  PHP_VER: 8.1.1
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.10
+                  PHP_VER: 8.0.14
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.10
+                  PHP_VER: 8.0.14
                   TS: 0
 
 build_script:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,9 @@ jobs:
          # NOTE: If this is not quoted, the yaml parser will convert 8.0 to the number 8,
          # and the docker image `php:8` is the latest minor version of php 8.x
          - PHP_VERSION: '8.0'
-           PHP_VERSION_FULL: 8.0.10
-         - PHP_VERSION: '8.1.0RC1'
-           PHP_VERSION_FULL: 8.1.0RC1
+           PHP_VERSION_FULL: 8.0.14
+         - PHP_VERSION: '8.1'
+           PHP_VERSION_FULL: 8.1.1
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,11 @@
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
 * Add Teds\array_value_first(), Teds\array_value_last()
+* Make Deque iteration account for calls to push/pop tracking the position of the front of the Deque.
+  Calls to shift/unshift will do the following:
+  - Increase/Decrease the value returned by the iterator's key() by the number of elements added/removed to/from the front of the Deque. (`$deque[$iteratorKey] === $iteratorValue` at the time the key and value are returned).
+  - Repeated calls to shift will cause valid() to return false if the iterator's position ends up before the start of the Deque at the time iteration resumes.
+  - They will not cause the remaining values to be iterated over more than once or skipped.
  </notes>
  <contents>
   <dir name="/">

--- a/teds_vector.c
+++ b/teds_vector.c
@@ -192,9 +192,6 @@ static void teds_vector_entries_init_from_traversable(teds_vector_entries *array
 		if (UNEXPECTED(EG(exception))) {
 			break;
 		}
-		if (UNEXPECTED(EG(exception))) {
-			break;
-		}
 
 		if (size >= capacity) {
 			/* Not using Countable::count(), that would potentially have side effects or throw UnsupportedOperationException or be slow to compute */

--- a/tests/Deque/foreach.phpt
+++ b/tests/Deque/foreach.phpt
@@ -1,0 +1,95 @@
+--TEST--
+Teds\Deque modification during foreach
+--FILE--
+<?php
+
+/** Creates a reference-counted version of a literal string to test reference counting. */
+function mut(string $s) {
+    $s[0] = $s[0];
+    return $s;
+}
+
+echo "Test push/unshift\n";
+$deque = new Teds\Deque(['a', 'b']);
+foreach ($deque as $key => $value) {
+    if (strlen($value) === 1) {
+        $deque->push("${value}_");
+        $deque->unshift("_${value}");
+    }
+    printf("Key: %s Value: %s\n", var_export($key, true), var_export($value, true));
+}
+var_dump($deque);
+echo "Test shift\n";
+foreach ($deque as $key => $value) {
+    echo "Shifting $key $value\n";
+    var_dump($deque->shift());
+}
+
+echo "Test shift out of bounds\n";
+$deque = new Teds\Deque([mut('a1'), mut('b1'), mut('c1')]);
+foreach ($deque as $key => $value) {
+    $deque->shift();
+    $deque->shift();
+    echo "Saw $key: $value\n";
+    // iteration stops early because iteration position is now out of bounds.
+}
+var_dump($deque);
+
+echo "Test iteration behavior\n";
+$deque = new Teds\Deque([mut('a1'), mut('a2')]);
+$it = $deque->getIterator();
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'value' => $it->current()]), "\n";
+$deque->shift();
+// invalid, outside the range of the deque
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key()]), "\n";
+$it->next();
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'value' => $it->current()]), "\n";
+$deque->unshift('a', 'b');
+unset($deque);
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'value' => $it->current()]), "\n";
+
+?>
+--EXPECT--
+Test push/unshift
+Key: 0 Value: 'a'
+Key: 2 Value: 'b'
+Key: 4 Value: 'a_'
+Key: 5 Value: 'b_'
+object(Teds\Deque)#1 (6) {
+  [0]=>
+  string(2) "_b"
+  [1]=>
+  string(2) "_a"
+  [2]=>
+  string(1) "a"
+  [3]=>
+  string(1) "b"
+  [4]=>
+  string(2) "a_"
+  [5]=>
+  string(2) "b_"
+}
+Test shift
+Shifting 0 _b
+string(2) "_b"
+Shifting 0 _a
+string(2) "_a"
+Shifting 0 a
+string(1) "a"
+Shifting 0 b
+string(1) "b"
+Shifting 0 a_
+string(2) "a_"
+Shifting 0 b_
+string(2) "b_"
+Test shift out of bounds
+Saw 0: a1
+object(Teds\Deque)#2 (1) {
+  [0]=>
+  string(2) "c1"
+}
+Test iteration behavior
+{"valid":true,"key":0,"value":"a1"}
+{"valid":false,"key":null}
+{"valid":true,"key":0,"value":"a2"}
+{"valid":true,"key":2,"value":"a2"}

--- a/tests/Deque/iterator.phpt
+++ b/tests/Deque/iterator.phpt
@@ -12,16 +12,17 @@ function expect_throws(Closure $cb): void {
     }
 }
 
-// Iterators are associated with an index (as in offsetGet), not a position in the deque.
+// Iterators are associated with a position in the deque relative to the front of the deque *when iteration started*. key() returns the distance from the current start of the deque, or null.
 $dq = new Teds\Deque([new stdClass(), strtoupper('test')]);
 $it = $dq->getIterator();
 var_dump($it->key());
 var_dump($it->current());
 var_dump($it->next());
 var_dump($it->valid());
+echo "After shift\n";
 $dq->shift();
 var_dump($it->key());
-expect_throws(fn() => $it->current());
+var_dump($it->current());
 var_dump($it->valid());
 $dq->shift();
 var_dump($it->key()); // null for invalid iterator
@@ -38,9 +39,10 @@ object(stdClass)#2 (0) {
 }
 NULL
 bool(true)
-NULL
-Caught OutOfBoundsException: Index out of range
-bool(false)
+After shift
+int(0)
+string(4) "TEST"
+bool(true)
 NULL
 Caught OutOfBoundsException: Index out of range
 bool(false)


### PR DESCRIPTION
(By tracking the position of the front of the Deque)

Calls to shift/unshift will do the following:
- Increase/Decrease the value returned by the iterator's key() by the number of
  elements added/removed to/from the front of the Deque.
  (`$deque[$iteratorKey] === $iteratorValue` at the time the key and value are returned).
- Repeated calls to shift will cause valid() to return false if the iterator's
  position ends up before the start of the Deque at the time iteration resumes.
- They will not cause the remaining values to
  be iterated over more than once or skipped.

Closes #31