### PR TITLE
0.9.1: Switch sorted map/set to binary tree, fix sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Much more efficient in memory usage and random access than SplDoublyLinkedList.
 
 [`Teds\SortedStrictMap` API](./teds_strictmap.stub.php)
 
-**This is a work in progress.** Iteration will not work as expected if elements are removed during iteration, and this is backed by a raw array (using insertion sort) instead of a balanced binary tree, so insertion/removals are inefficient for large maps.
-
 This is a map where entries for keys of any type can be inserted if `Teds\stable_compare !== 0`.
+
+**This is a work in progress.** This is currently using an **unbalanced** binary search tree (balancing is planned), so insertions/removals are inefficient for sorted values resulting in unbalanced trees.
+Iteration will stop if the current key of an iterator is removed.
+
 This uses [`Teds\stable_compare`](#stable-comparison) internally.
 
 The [`Teds\SortedStrictSet` API](./teds_sortedstrictset.stub.php) implementation is similar, but does not associate values with keys and does not implement ArrayAccess and uses different method names.

--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-01-23</date>
+ <date>2022-01-29</date>
  <time>16:00:00</time>
  <version>
-  <release>0.9.1dev</release>
-  <api>0.9.1dev</api>
+  <release>0.9.1</release>
+  <api>0.9.1</api>
  </version>
  <stability>
   <release>stable</release>
@@ -22,7 +22,10 @@
  </stability>
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* Migrate `Teds\StrictSet`, `Teds\StrictMap`, and `Teds\unique_values` implementation to use an actual hash table instead of a list of unique values.
+* Make SortedStrictSet/SortedStrictMap use a binary search tree (not yet a balanced tree).
+* Associate iterators on SortedStrictSet/SortedStrictMap with nodes of the tree.
+  Invalidate iterators pointing to a node when that node of the set/map is removed.
+* Fix sorting order when instantiating StableSortedListSet/SortedStrictSet/SortedStrictMap from unsorted arrays.
  </notes>
  <contents>
   <dir name="/">
@@ -162,10 +165,13 @@
     <file name="SortedStrictMap/exceptionhandler.phpt" role="test" />
     <file name="SortedStrictMap/from_pairs.phpt" role="test" />
     <file name="SortedStrictMap/gc.phpt" role="test" />
+    <file name="SortedStrictMap/iteration_delete.phpt" role="test" />
+    <file name="SortedStrictMap/iteration_insert.phpt" role="test" />
     <file name="SortedStrictMap/keys_values.phpt" role="test" />
     <file name="SortedStrictMap/offsetExists.phpt" role="test" />
     <file name="SortedStrictMap/reinit_forbidden.phpt" role="test" />
     <file name="SortedStrictMap/remove.phpt" role="test" />
+    <file name="SortedStrictMap/remove_single.phpt" role="test" />
     <file name="SortedStrictMap/serialization.phpt" role="test" />
     <file name="SortedStrictMap/shift.phpt" role="test" />
     <file name="SortedStrictMap/traversable.phpt" role="test" />
@@ -178,6 +184,8 @@
     <file name="SortedStrictSet/contains.phpt" role="test" />
     <file name="SortedStrictSet/exceptionhandler.phpt" role="test" />
     <file name="SortedStrictSet/gc.phpt" role="test" />
+    <file name="SortedStrictSet/iteration_delete.phpt" role="test" />
+    <file name="SortedStrictSet/iteration_insert.phpt" role="test" />
     <file name="SortedStrictSet/reinit_forbidden.phpt" role="test" />
     <file name="SortedStrictSet/serialization.phpt" role="test" />
     <file name="SortedStrictSet/set_state.phpt" role="test" />

--- a/php_teds.h
+++ b/php_teds.h
@@ -23,7 +23,7 @@ extern zend_module_entry teds_module_entry;
 
 PHP_MINIT_FUNCTION(teds);
 
-# define PHP_TEDS_VERSION "0.9.1dev"
+# define PHP_TEDS_VERSION "0.9.1"
 
 # if defined(ZTS) && defined(COMPILE_DL_TEDS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/teds_sortedstrictmap.h
+++ b/teds_sortedstrictmap.h
@@ -12,4 +12,104 @@
 
 PHP_MINIT_FUNCTION(teds_sortedstrictmap);
 
+typedef struct _teds_sortedstrictmap_node {
+	zval key;
+	zval value;
+
+	struct _teds_sortedstrictmap_node *left;
+	struct _teds_sortedstrictmap_node *right;
+	struct _teds_sortedstrictmap_node *parent;
+	struct _teds_sortedstrictmap_node *prev;
+	struct _teds_sortedstrictmap_node *next;
+} teds_sortedstrictmap_node;
+
+#define TEDS_SORTEDSTRICTMAP_NODE_REFCOUNT(node) Z_EXTRA((node)->key)
+
+typedef struct _teds_sortedstrictmap_tree {
+	struct _teds_sortedstrictmap_node *root;
+	size_t nNumOfElements;
+	bool initialized;
+} teds_sortedstrictmap_tree;
+
+typedef struct _teds_sortedstrictmap {
+	teds_sortedstrictmap_tree	array;
+	zend_object					std;
+} teds_sortedstrictmap;
+
+void teds_sortedstrictmap_tree_init_from_array(teds_sortedstrictmap_tree *array, zend_array *values);
+
+void teds_sortedstrictmap_tree_init_from_traversable(teds_sortedstrictmap_tree *array, zend_object *obj);
+
+void teds_sortedstrictmap_tree_dtor(teds_sortedstrictmap_tree *array);
+
+void teds_sortedstrictmap_tree_dtor_range(teds_sortedstrictmap_node *start, size_t from, size_t to);
+
+static zend_always_inline teds_sortedstrictmap_node *teds_sortedstrictmap_tree_get_first(const teds_sortedstrictmap_tree *tree)
+{
+	teds_sortedstrictmap_node *it = tree->root;
+	if (it == NULL) {
+		return NULL;
+	}
+	while (true) {
+		if (!it->left) {
+			return it;
+		}
+		it = it->left;
+	}
+}
+
+static zend_always_inline teds_sortedstrictmap_node *teds_sortedstrictmap_tree_get_last(const teds_sortedstrictmap_tree *tree)
+{
+	teds_sortedstrictmap_node *it = tree->root;
+	if (it == NULL) {
+		return NULL;
+	}
+	while (true) {
+		if (!it->right) {
+			return it;
+		}
+		it = it->right;
+	}
+}
+
+#define TEDS_SORTEDSTRICTMAP_FOREACH(_sortedstrictmap) do { \
+	const teds_sortedstrictmap_tree *const __sortedstrictmap = (_sortedstrictmap); \
+	teds_sortedstrictmap_node *_p = teds_sortedstrictmap_tree_get_first(__sortedstrictmap); \
+	if (_p) { ZEND_ASSERT(__sortedstrictmap->nNumOfElements > 0); } else { ZEND_ASSERT(__sortedstrictmap->nNumOfElements == 0); } \
+	while (_p != NULL) {
+
+#define TEDS_SORTEDSTRICTMAP_FOREACH_END() \
+		_p = _p->next; \
+	} \
+} while (0)
+
+#define TEDS_SORTEDSTRICTMAP_FOREACH_KEY_VAL(sortedstrictmap, k, v) TEDS_SORTEDSTRICTMAP_FOREACH(sortedstrictmap) \
+	k = &_p->key; \
+	v = &_p->value;
+
+#define TEDS_SORTEDSTRICTMAP_FOREACH_KEY(sortedstrictmap, k) TEDS_SORTEDSTRICTMAP_FOREACH(sortedstrictmap) \
+	k = &_p->key;
+
+#define TEDS_SORTEDSTRICTMAP_FOREACH_VAL(sortedstrictmap, v) TEDS_SORTEDSTRICTMAP_FOREACH(sortedstrictmap) \
+	v = &_p->value;
+
+#define TEDS_SORTEDSTRICTMAP_FOREACH_NODE(sortedstrictmap, node) TEDS_SORTEDSTRICTMAP_FOREACH(sortedstrictmap) \
+	node = _p;
+
+
+/* Helps enforce the invariants in debug mode:
+ *   - if capacity == 0, then entries == NULL
+ *   - if capacity > 0, then entries != NULL
+ */
+static zend_always_inline bool teds_sortedstrictmap_tree_empty_size(const teds_sortedstrictmap_tree *array)
+{
+	if (array->nNumOfElements > 0) {
+		ZEND_ASSERT(array->root != NULL);
+		ZEND_ASSERT(array->initialized);
+		return false;
+	}
+	ZEND_ASSERT(array->root == NULL);
+	return true;
+}
+
 #endif	/* TEDS_SORTEDSTRICTMAP_H */

--- a/teds_sortedstrictmap.stub.php
+++ b/teds_sortedstrictmap.stub.php
@@ -105,6 +105,7 @@ final class SortedStrictMap implements \IteratorAggregate, \Countable, \JsonSeri
 
     /**
      * Returns [[key1, value1], [key2, value2]]
+     * @implementation-alias Teds\SortedStrictMap::toPairs
      */
     public function jsonSerialize(): array {}
 }

--- a/teds_sortedstrictmap_arginfo.h
+++ b/teds_sortedstrictmap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a18fdbea1abb06e764261451cdc37e70729e9fcb */
+ * Stub hash: bf00305e3417798e444dd5009b6b176a4c2826a2 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_SortedStrictMap___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -107,7 +107,6 @@ ZEND_METHOD(Teds_SortedStrictMap, offsetUnset);
 ZEND_METHOD(Teds_SortedStrictMap, get);
 ZEND_METHOD(Teds_SortedStrictMap, containsValue);
 ZEND_METHOD(Teds_SortedStrictMap, containsKey);
-ZEND_METHOD(Teds_SortedStrictMap, jsonSerialize);
 
 
 static const zend_function_entry class_Teds_SortedStrictMap_methods[] = {
@@ -136,7 +135,7 @@ static const zend_function_entry class_Teds_SortedStrictMap_methods[] = {
 	ZEND_ME(Teds_SortedStrictMap, get, arginfo_class_Teds_SortedStrictMap_get, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_SortedStrictMap, containsValue, arginfo_class_Teds_SortedStrictMap_containsValue, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_SortedStrictMap, containsKey, arginfo_class_Teds_SortedStrictMap_containsKey, ZEND_ACC_PUBLIC)
-	ZEND_ME(Teds_SortedStrictMap, jsonSerialize, arginfo_class_Teds_SortedStrictMap_jsonSerialize, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_SortedStrictMap, jsonSerialize, toPairs, arginfo_class_Teds_SortedStrictMap_jsonSerialize, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/teds_sortedstrictset.h
+++ b/teds_sortedstrictset.h
@@ -12,4 +12,92 @@
 
 PHP_MINIT_FUNCTION(teds_sortedstrictset);
 
+typedef struct _teds_sortedstrictset_node {
+	zval key;
+
+	struct _teds_sortedstrictset_node *left;
+	struct _teds_sortedstrictset_node *right;
+	struct _teds_sortedstrictset_node *parent;
+	struct _teds_sortedstrictset_node *prev;
+	struct _teds_sortedstrictset_node *next;
+} teds_sortedstrictset_node;
+
+#define TEDS_SORTEDSTRICTSET_NODE_REFCOUNT(node) Z_EXTRA((node)->key)
+
+typedef struct _teds_sortedstrictset_tree {
+	struct _teds_sortedstrictset_node *root;
+	size_t nNumOfElements;
+	bool initialized;
+} teds_sortedstrictset_tree;
+
+typedef struct _teds_sortedstrictset {
+	teds_sortedstrictset_tree	array;
+	zend_object					std;
+} teds_sortedstrictset;
+
+void teds_sortedstrictset_tree_init_from_array(teds_sortedstrictset_tree *array, zend_array *values);
+
+void teds_sortedstrictset_tree_init_from_traversable(teds_sortedstrictset_tree *array, zend_object *obj);
+
+void teds_sortedstrictset_tree_dtor(teds_sortedstrictset_tree *array);
+
+void teds_sortedstrictset_tree_dtor_range(teds_sortedstrictset_node *start, size_t from, size_t to);
+
+static zend_always_inline teds_sortedstrictset_node *teds_sortedstrictset_tree_get_first(const teds_sortedstrictset_tree *tree)
+{
+	teds_sortedstrictset_node *it = tree->root;
+	if (it == NULL) {
+		return NULL;
+	}
+	while (true) {
+		if (!it->left) {
+			return it;
+		}
+		it = it->left;
+	}
+}
+
+static zend_always_inline teds_sortedstrictset_node *teds_sortedstrictset_tree_get_last(const teds_sortedstrictset_tree *tree)
+{
+	teds_sortedstrictset_node *it = tree->root;
+	if (it == NULL) {
+		return NULL;
+	}
+	while (true) {
+		if (!it->right) {
+			return it;
+		}
+		it = it->right;
+	}
+}
+
+#define TEDS_SORTEDSTRICTSET_FOREACH(_sortedstrictset) do { \
+	const teds_sortedstrictset_tree *const __sortedstrictset = (_sortedstrictset); \
+	teds_sortedstrictset_node *_p = teds_sortedstrictset_tree_get_first(__sortedstrictset); \
+	if (_p) { ZEND_ASSERT(__sortedstrictset->nNumOfElements > 0); } else { ZEND_ASSERT(__sortedstrictset->nNumOfElements == 0); } \
+	while (_p != NULL) {
+
+#define TEDS_SORTEDSTRICTSET_FOREACH_END() \
+		_p = _p->next; \
+	} \
+} while (0)
+
+#define TEDS_SORTEDSTRICTSET_FOREACH_KEY(sortedstrictset, k) TEDS_SORTEDSTRICTSET_FOREACH(sortedstrictset) \
+	k = &_p->key;
+
+/* Helps enforce the invariants in debug mode:
+ *   - if capacity == 0, then entries == NULL
+ *   - if capacity > 0, then entries != NULL
+ */
+static zend_always_inline bool teds_sortedstrictset_tree_empty_size(const teds_sortedstrictset_tree *array)
+{
+	if (array->nNumOfElements > 0) {
+		ZEND_ASSERT(array->root != NULL);
+		ZEND_ASSERT(array->initialized);
+		return false;
+	}
+	ZEND_ASSERT(array->root == NULL);
+	return true;
+}
+
 #endif	/* TEDS_SORTEDSTRICTSET_H */

--- a/teds_strictmap.c
+++ b/teds_strictmap.c
@@ -216,11 +216,9 @@ void teds_strictmap_entries_init_from_array(teds_strictmap_entries *array, zend_
 				ZVAL_LONG(&key, nkey);
 			}
 			ZVAL_DEREF(val);
-			if (!teds_strictmap_entries_insert(array, &key, val, true)) {
-				if (skey) {
-					GC_DELREF(skey);
-				}
-			}
+			/* key is unique in an array */
+			bool result = teds_strictmap_entries_insert(array, &key, val, true);
+			ZEND_ASSERT(result);
 		} ZEND_HASH_FOREACH_END();
 	} else {
 		teds_strictmap_entries_set_empty_entry_list(array);

--- a/tests/SortedStrictMap/SortedStrictMap.phpt
+++ b/tests/SortedStrictMap/SortedStrictMap.phpt
@@ -15,6 +15,7 @@ var_dump($it);
 var_dump((array)$it);
 foreach ($it as $key => $value) {
     echo "Unreachable\n";
+    var_dump($key, $value);
 }
 
 ?>

--- a/tests/SortedStrictMap/exceptionhandler.phpt
+++ b/tests/SortedStrictMap/exceptionhandler.phpt
@@ -11,9 +11,10 @@ class HasDestructor {
 }
 
 function yields_and_throws() {
-    yield 123 => new HasDestructor('in value');
+    yield 123 => new HasDestructor('in value1');
     yield new HasDestructor('in key') => 123;
-    yield 123 => new HasDestructor('in value');
+    yield 123 => new HasDestructor('in value2');
+    echo "Overridden\n";
     yield 'first' => 'second';
 
     throw new RuntimeException('test');
@@ -29,8 +30,9 @@ gc_collect_cycles();
 echo "Done\n";
 ?>
 --EXPECT--
-in HasDestructor::__destruct in value
+in HasDestructor::__destruct in value1
+Overridden
+in HasDestructor::__destruct in value2
 in HasDestructor::__destruct in key
-in HasDestructor::__destruct in value
 Caught test
 Done

--- a/tests/SortedStrictMap/iteration_delete.phpt
+++ b/tests/SortedStrictMap/iteration_delete.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Teds\SortedStrictMap delete during iteration
+--FILE--
+<?php
+
+$map = new Teds\SortedStrictMap(['first' => 'x', 'second' => new stdClass()]);
+$it = $map->getIterator();
+foreach ($it as $key => $value) {
+    unset($map[$key]);
+    printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
+}
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+$it->rewind();
+var_dump($map);
+echo "After rewind\n";
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+foreach ($it as $key => $value) {
+    unset($map[$key]);
+    printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
+}
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+var_dump($map);
+
+?>
+--EXPECT--
+Key: 'first'
+Value: 'x'
+{"valid":false,"key":null,"current":null}
+object(Teds\SortedStrictMap)#1 (1) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(6) "second"
+    [1]=>
+    object(stdClass)#2 (0) {
+    }
+  }
+}
+After rewind
+{"valid":true,"key":"second","current":{}}
+Key: 'second'
+Value: (object) array(
+)
+{"valid":false,"key":null,"current":null}
+object(Teds\SortedStrictMap)#1 (0) {
+}

--- a/tests/SortedStrictMap/iteration_insert.phpt
+++ b/tests/SortedStrictMap/iteration_insert.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Teds\SortedStrictMap insert during iteration
+--FILE--
+<?php
+
+function create_key(int $i) {
+    return "x$i";
+}
+$map = new Teds\SortedStrictMap([create_key(0) => 'x', create_key(2) => create_key(100), create_key(5) => 'a']);
+foreach ($map as $key => $value) {
+    $map[create_key(1)] = create_key(123);
+    $map[create_key(2)] = create_key(124);
+    $map[create_key(9)] = create_key(125);
+    printf("Key: %s\nValue: %s\n", $key, $value);
+}
+var_dump($map);
+?>
+--EXPECT--
+Key: x0
+Value: x
+Key: x1
+Value: x123
+Key: x2
+Value: x124
+Key: x5
+Value: a
+Key: x9
+Value: x125
+object(Teds\SortedStrictMap)#1 (5) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(2) "x0"
+    [1]=>
+    string(1) "x"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    string(2) "x1"
+    [1]=>
+    string(4) "x123"
+  }
+  [2]=>
+  array(2) {
+    [0]=>
+    string(2) "x2"
+    [1]=>
+    string(4) "x124"
+  }
+  [3]=>
+  array(2) {
+    [0]=>
+    string(2) "x5"
+    [1]=>
+    string(1) "a"
+  }
+  [4]=>
+  array(2) {
+    [0]=>
+    string(2) "x9"
+    [1]=>
+    string(4) "x125"
+  }
+}

--- a/tests/SortedStrictMap/remove_single.phpt
+++ b/tests/SortedStrictMap/remove_single.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Teds\SortedStrictMap remove single value
+--FILE--
+<?php
+
+$map = new Teds\SortedStrictMap();
+$o1 = new stdClass();
+$map[$o1] = new stdClass();
+var_dump($map);
+printf("count=%d\n", count($map));
+unset($map[$o1]);
+var_dump($map);
+printf("count=%d\n", count($map));
+
+?>
+--EXPECT--
+object(Teds\SortedStrictMap)#1 (1) {
+  [0]=>
+  array(2) {
+    [0]=>
+    object(stdClass)#2 (0) {
+    }
+    [1]=>
+    object(stdClass)#3 (0) {
+    }
+  }
+}
+count=1
+object(Teds\SortedStrictMap)#1 (0) {
+}
+count=0

--- a/tests/SortedStrictMap/traversable.phpt
+++ b/tests/SortedStrictMap/traversable.phpt
@@ -39,6 +39,8 @@ echo "Done\n";
 ?>
 --EXPECT--
 Done evaluating the generator
+Key: 0
+Value: 2
 Key: 'r0'
 Value: 's0'
 Key: 'r1'
@@ -65,11 +67,9 @@ Key: (object) array(
 Value: (object) array(
    'key' => 'value',
 )
-Key: 0
-Value: 1
-Key: 0
-Value: 2
 Rewind and iterate again starting from r0
+Key: 0
+Value: 2
 Key: 'r0'
 Value: 's0'
 Key: 'r1'
@@ -96,10 +96,6 @@ Key: (object) array(
 Value: (object) array(
    'key' => 'value',
 )
-Key: 0
-Value: 1
-Key: 0
-Value: 2
 object(Teds\SortedStrictMap)#1 (0) {
 }
 Done

--- a/tests/SortedStrictSet/add.phpt
+++ b/tests/SortedStrictSet/add.phpt
@@ -27,6 +27,8 @@ printf("count=%d\n", count($it));
 var_dump($it);
 echo "Remove results\n";
 foreach ($it->values() as $v) {
+    echo "Remove: ";
+    var_dump($v);
     $remove($v);
 }
 var_dump($it);
@@ -76,9 +78,15 @@ object(Teds\SortedStrictSet)#1 (4) {
   }
 }
 Remove results
+Remove: string(1) "0"
 bool(true)
+Remove: string(5) "EXTRA"
 bool(true)
+Remove: object(stdClass)#4 (0) {
+}
 bool(true)
+Remove: object(stdClass)#5 (0) {
+}
 bool(true)
 object(Teds\SortedStrictSet)#1 (0) {
 }

--- a/tests/SortedStrictSet/clone.phpt
+++ b/tests/SortedStrictSet/clone.phpt
@@ -3,7 +3,10 @@ Teds\SortedStrictSet can be cloned
 --FILE--
 <?php
 
-$it = new Teds\SortedStrictSet([new stdClass(), new ArrayObject()]);
+class A {}
+class B {}
+class C {}
+$it = new Teds\SortedStrictSet([new A(), new B(), new C(), new A()]);
 $it2 = clone $it;
 unset($it);
 foreach ($it2 as $value) {
@@ -11,10 +14,11 @@ foreach ($it2 as $value) {
 }
 ?>
 --EXPECT--
-object(stdClass)#2 (0) {
+object(A)#2 (0) {
 }
-object(ArrayObject)#3 (1) {
-  ["storage":"ArrayObject":private]=>
-  array(0) {
-  }
+object(A)#5 (0) {
+}
+object(B)#3 (0) {
+}
+object(C)#4 (0) {
 }

--- a/tests/SortedStrictSet/iteration_delete.phpt
+++ b/tests/SortedStrictSet/iteration_delete.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Teds\SortedStrictSet delete during iteration
+--FILE--
+<?php
+
+$set = new Teds\SortedStrictSet(['x', new stdClass()]);
+$it = $set->getIterator();
+foreach ($it as $value) {
+    var_dump($set->remove($value));
+    printf("Value: %s\n", var_export($value, true));
+}
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+$it->rewind();
+var_dump($set);
+echo "After rewind\n";
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+foreach ($it as $key => $value) {
+    var_dump($set->remove($value));
+    printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
+}
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+var_dump($set);
+
+?>
+--EXPECT--
+bool(true)
+Value: 'x'
+{"valid":false,"key":null,"current":null}
+object(Teds\SortedStrictSet)#1 (1) {
+  [0]=>
+  object(stdClass)#2 (0) {
+  }
+}
+After rewind
+{"valid":true,"key":{},"current":{}}
+bool(true)
+Key: (object) array(
+)
+Value: (object) array(
+)
+{"valid":false,"key":null,"current":null}
+object(Teds\SortedStrictSet)#1 (0) {
+}

--- a/tests/SortedStrictSet/iteration_insert.phpt
+++ b/tests/SortedStrictSet/iteration_insert.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Teds\SortedStrictSet insert during iteration
+--FILE--
+<?php
+
+function create_key(int $i) {
+    return "x$i";
+}
+$map = new Teds\SortedStrictSet([create_key(0), create_key(2), create_key(5)]);
+foreach ($map as $key => $value) {
+    var_dump(
+        $map->add(create_key(1)),
+        $map->add(create_key(2)),
+        $map->add(create_key(9)),
+    );
+    printf("Key: %s\nValue: %s\n", $key, $value);
+}
+var_dump($map);
+?>
+--EXPECT--
+bool(true)
+bool(false)
+bool(true)
+Key: x0
+Value: x0
+bool(false)
+bool(false)
+bool(false)
+Key: x1
+Value: x1
+bool(false)
+bool(false)
+bool(false)
+Key: x2
+Value: x2
+bool(false)
+bool(false)
+bool(false)
+Key: x5
+Value: x5
+bool(false)
+bool(false)
+bool(false)
+Key: x9
+Value: x9
+object(Teds\SortedStrictSet)#1 (5) {
+  [0]=>
+  string(2) "x0"
+  [1]=>
+  string(2) "x1"
+  [2]=>
+  string(2) "x2"
+  [3]=>
+  string(2) "x5"
+  [4]=>
+  string(2) "x9"
+}

--- a/tests/SortedStrictSet/traversable.phpt
+++ b/tests/SortedStrictSet/traversable.phpt
@@ -39,6 +39,8 @@ echo "Done\n";
 ?>
 --EXPECT--
 Done evaluating the generator
+Value: 1
+Value: 2
 Value: 's0'
 Value: 's1'
 Value: 's2'
@@ -52,9 +54,9 @@ Value: 's9'
 Value: (object) array(
    'key' => 'value',
 )
-Value: 1
-Value: 2
 Rewind and iterate again starting from r0
+Value: 1
+Value: 2
 Value: 's0'
 Value: 's1'
 Value: 's2'
@@ -68,8 +70,6 @@ Value: 's9'
 Value: (object) array(
    'key' => 'value',
 )
-Value: 1
-Value: 2
 object(Teds\SortedStrictSet)#1 (0) {
 }
 Done

--- a/tests/StableSortedListMap/exceptionhandler.phpt
+++ b/tests/StableSortedListMap/exceptionhandler.phpt
@@ -11,9 +11,10 @@ class HasDestructor {
 }
 
 function yields_and_throws() {
-    yield 123 => new HasDestructor('in value');
+    yield 123 => new HasDestructor('in value1');
     yield new HasDestructor('in key') => 123;
-    yield 123 => new HasDestructor('in value');
+    yield 123 => new HasDestructor('in value2');
+    echo "Overridden\n";
     yield 'first' => 'second';
 
     throw new RuntimeException('test');
@@ -29,8 +30,9 @@ gc_collect_cycles();
 echo "Done\n";
 ?>
 --EXPECT--
-in HasDestructor::__destruct in value
+in HasDestructor::__destruct in value1
+Overridden
+in HasDestructor::__destruct in value2
 in HasDestructor::__destruct in key
-in HasDestructor::__destruct in value
 Caught test
 Done

--- a/tests/StableSortedListMap/traversable.phpt
+++ b/tests/StableSortedListMap/traversable.phpt
@@ -39,6 +39,8 @@ echo "Done\n";
 ?>
 --EXPECT--
 Done evaluating the generator
+Key: 0
+Value: 2
 Key: 'r0'
 Value: 's0'
 Key: 'r1'
@@ -65,11 +67,9 @@ Key: (object) array(
 Value: (object) array(
    'key' => 'value',
 )
-Key: 0
-Value: 1
-Key: 0
-Value: 2
 Rewind and iterate again starting from r0
+Key: 0
+Value: 2
 Key: 'r0'
 Value: 's0'
 Key: 'r1'
@@ -96,10 +96,6 @@ Key: (object) array(
 Value: (object) array(
    'key' => 'value',
 )
-Key: 0
-Value: 1
-Key: 0
-Value: 2
 object(Teds\StableSortedListMap)#1 (0) {
 }
 Done


### PR DESCRIPTION
Fix sorting when constructing sorted structures from unsorted arrays/traversables.

Use a binary tree for SortedStrictMap/SortedStrictSet
(not yet balanced).
Associate iterators with nodes of the binary tree and invalidate
iterators when nodes are deleted.

Closes #96
Related to #64