### PR TITLE
Implement basic functionality of a low memory vector

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -110,5 +110,5 @@ if test "$PHP_TEDS" != "no"; then
   dnl In case of no dependencies
   AC_DEFINE(HAVE_TEDS, 1, [ Have teds support ])
 
-  PHP_NEW_EXTENSION(teds, teds.c teds_immutablesequence.c teds_immutablekeyvaluesequence.c teds_keyvaluevector.c teds_vector.c teds_deque.c teds_sortedstrictmap.c teds_sortedstrictset.c teds_stableheap.c teds_strictmap.c teds_strictset.c teds_stablesortedlistset.c teds_stablesortedlistmap.c, $ext_shared)
+  PHP_NEW_EXTENSION(teds, teds.c teds_immutablesequence.c teds_immutablekeyvaluesequence.c teds_keyvaluevector.c teds_vector.c teds_deque.c teds_sortedstrictmap.c teds_sortedstrictset.c teds_stableheap.c teds_strictmap.c teds_strictset.c teds_stablesortedlistset.c teds_stablesortedlistmap.c teds_lowmemoryvector.c, $ext_shared)
 fi

--- a/config.w32
+++ b/config.w32
@@ -3,5 +3,5 @@ ARG_ENABLE('teds', 'teds support', 'no');
 if (PHP_TEDS != 'no') {
 	AC_DEFINE('HAVE_TEDS', 1, 'teds support enabled');
 
-	EXTENSION('teds', 'teds.c teds_immutablekeyvaluesequence.c teds_immutablesequence.c teds_keyvaluevector.c teds_vector.c teds_deque.c teds_sortedstrictmap.c teds_sortedstrictset.c teds_stableheap.c teds_strictmap.c teds_strictset.c teds_stablesortedlistset.c teds_stablesortedlistmap.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	EXTENSION('teds', 'teds.c teds_immutablekeyvaluesequence.c teds_immutablesequence.c teds_keyvaluevector.c teds_vector.c teds_deque.c teds_sortedstrictmap.c teds_sortedstrictset.c teds_stableheap.c teds_strictmap.c teds_strictset.c teds_stablesortedlistset.c teds_stablesortedlistmap.c teds_lowmemoryvector.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 }

--- a/teds.c
+++ b/teds.c
@@ -31,6 +31,7 @@
 #include "ext/standard/info.h"
 
 #include "teds_deque.h"
+#include "teds_lowmemoryvector.h"
 #include "teds_immutablekeyvaluesequence.h"
 #include "teds_immutablesequence.h"
 #include "teds_keyvaluevector.h"
@@ -1072,6 +1073,7 @@ PHP_MINIT_FUNCTION(teds)
 	PHP_MINIT(teds_immutablekeyvaluesequence)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(teds_immutablesequence)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(teds_keyvaluevector)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(teds_lowmemoryvector)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(teds_sortedstrictmap)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(teds_sortedstrictset)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(teds_stableheap)(INIT_FUNC_ARGS_PASSTHRU);

--- a/teds_lowmemoryvector.c
+++ b/teds_lowmemoryvector.c
@@ -1,0 +1,1365 @@
+/*
+  +----------------------------------------------------------------------+
+  | teds extension for PHP                                               |
+  | See COPYING file for further copyright information                   |
+  +----------------------------------------------------------------------+
+  | Author: Tyson Andre <tandre@php.net>                                 |
+  +----------------------------------------------------------------------+
+*/
+
+/* This is based on spl_fixedarray.c but has lower overhead (when size is known) and is more efficient to push and remove elements from the end of the list */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_ini.h"
+#include "ext/standard/info.h"
+#include "zend_exceptions.h"
+
+#include "php_teds.h"
+#include "teds.h"
+#include "teds_lowmemoryvector_arginfo.h"
+#include "teds_lowmemoryvector.h"
+// #include "ext/spl/spl_functions.h"
+#include "ext/spl/spl_exceptions.h"
+#include "ext/spl/spl_iterators.h"
+#include "ext/json/php_json.h"
+#include "teds_util.h"
+
+#include <stdbool.h>
+
+/* Though rare, it is possible to have 64-bit zend_longs and a 32-bit size_t. */
+#define MAX_ZVAL_COUNT ((SIZE_MAX / sizeof(zval)) - 1)
+#define MAX_VALID_OFFSET ((size_t)(MAX_ZVAL_COUNT > ZEND_LONG_MAX ? ZEND_LONG_MAX : MAX_ZVAL_COUNT))
+
+zend_object_handlers teds_handler_LowMemoryVector;
+zend_class_entry *teds_ce_LowMemoryVector;
+
+/* This is a placeholder value to distinguish between empty and uninitialized LowMemoryVector instances.
+ * Compilers require at least one element. Make this constant - reads/writes should be impossible. */
+static const zval empty_entry_list[1];
+
+#define LMV_TYPE_UNINITIALIZED  0
+#define LMV_TYPE_BOOL_OR_NULL   1
+#define LMV_TYPE_INT8           2
+#define LMV_TYPE_INT32          3
+#if SIZEOF_ZEND_LONG > 4
+#define LMV_TYPE_INT64          4
+#define LMV_TYPE_LAST_NONREFCOUNTED LMV_TYPE_INT64
+#else
+#define LMV_TYPE_LAST_NONREFCOUNTED LMV_TYPE_INT32
+#endif
+
+#define LMV_TYPE_LAST_GC_NO_SIDE_EFFECTS LMV_TYPE_LAST_NONREFCOUNTED
+
+#define LMV_TYPE_ZVAL           5
+#define LMV_TYPE_COUNT          LMV_TYPE_ZVAL + 1
+
+#ifdef LMV_TYPE_INT64
+#if LMV_TYPE_LAST_NONREFCOUNTED + 1 != LMV_TYPE_ZVAL
+#error need to update tables
+#endif
+#endif
+static const uint8_t teds_lmv_memory_per_element[LMV_TYPE_ZVAL + 1] = {
+	0,
+	sizeof(int8_t),  /* LMV_TYPE_BOOL_OR_NULL */
+	sizeof(int8_t),  /* LMV_TYPE_INT8 */
+	sizeof(int32_t), /* LMV_TYPE_INT32 */
+	sizeof(int64_t), /* LMV_TYPE_INT64 */
+	sizeof(zval),    /* LMV_TYPE_ZVAL */
+};
+
+typedef struct _teds_lowmemoryvector_entries {
+	size_t size;
+	size_t capacity;
+	union {
+		uint8_t     *entries_uint8;
+		int8_t      *entries_int8;
+		int32_t     *entries_int32;
+#ifdef LMV_TYPE_INT64
+		int64_t     *entries_int64;
+#endif
+		/*double      *entries_double; */
+		/*zend_string *entries_string; */
+		zval        *entries_zval;
+		void        *entries_raw;
+	};
+	int8_t type_tag;
+} teds_lowmemoryvector_entries;
+
+typedef struct _teds_lowmemoryvector {
+	teds_lowmemoryvector_entries		array;
+	zend_object				std;
+} teds_lowmemoryvector;
+
+/* Used by InternalIterator returned by LowMemoryVector->getIterator() */
+typedef struct _teds_lowmemoryvector_it {
+	zend_object_iterator intern;
+	zend_long            current;
+	/* Temporary memory location to store the most recent get_current_value() result */
+	zval                 tmp;
+} teds_lowmemoryvector_it;
+
+static void teds_lowmemoryvector_entries_raise_capacity(teds_lowmemoryvector_entries *intern, const size_t new_capacity);
+static zend_always_inline void teds_lowmemoryvector_entries_push(teds_lowmemoryvector_entries *array, const zval *value, const bool check_capacity);
+static zend_always_inline void teds_lowmemoryvector_entries_update_type_tag(teds_lowmemoryvector_entries *array, const zval *val);
+static zend_always_inline void teds_lowmemoryvector_entries_copy_offset(const teds_lowmemoryvector_entries *array, const zend_ulong offset, zval *dst, bool increase_refcount, bool pop);
+static zend_always_inline zval *teds_lowmemoryvector_entries_read_offset(const teds_lowmemoryvector_entries *intern, const zend_ulong offset, zval *tmp);
+static void teds_lowmemoryvector_entries_init_from_array_values(teds_lowmemoryvector_entries *array, zend_array *raw_data);
+static zend_always_inline void teds_lowmemoryvector_entries_set_type(zval *dst, const uint8_t type) {
+	ZEND_ASSERT(type >= IS_NULL && type <= IS_TRUE);
+	Z_TYPE_INFO_P(dst) = type;
+}
+
+static zend_always_inline uint8_t teds_lowmemoryvector_entries_get_type(const zval *dst) {
+	const uint8_t type = Z_TYPE_P(dst);
+	ZEND_ASSERT(type >= IS_NULL && type <= IS_TRUE);
+	return type;
+}
+
+/*
+ * If a size this large is encountered, assume the allocation will likely fail or
+ * future changes to the capacity will overflow.
+ */
+static ZEND_COLD void teds_error_noreturn_max_lowmemoryvector_capacity()
+{
+	zend_error_noreturn(E_ERROR, "exceeded max valid Teds\\LowMemoryVector capacity");
+}
+
+static teds_lowmemoryvector *teds_lowmemoryvector_from_object(zend_object *obj)
+{
+	return (teds_lowmemoryvector*)((char*)(obj) - XtOffsetOf(teds_lowmemoryvector, std));
+}
+
+#define Z_LOWMEMORYVECTOR_P(zv)  (teds_lowmemoryvector_from_object(Z_OBJ_P((zv))))
+#define Z_LOWMEMORYVECTOR_ENTRIES_P(zv)  (&(Z_LOWMEMORYVECTOR_P((zv))->array))
+
+/* Helps enforce the invariants in debug mode:
+ *   - if size == 0, then entries == NULL
+ *   - if size > 0, then entries != NULL
+ *   - size is not less than 0
+ */
+static bool teds_lowmemoryvector_entries_empty_size(const teds_lowmemoryvector_entries *array)
+{
+	if (array->size > 0) {
+		ZEND_ASSERT(array->entries_zval != empty_entry_list);
+		ZEND_ASSERT(array->capacity >= array->size);
+		return false;
+	}
+	return true;
+}
+
+static bool teds_lowmemoryvector_entries_empty_capacity(const teds_lowmemoryvector_entries *array)
+{
+	if (array->capacity > 0) {
+		ZEND_ASSERT(array->entries_zval != empty_entry_list);
+		return false;
+	}
+	// This lowmemoryvector may have reserved capacity.
+	return true;
+}
+
+static bool teds_lowmemoryvector_entries_uninitialized(const teds_lowmemoryvector_entries *array)
+{
+	if (array->entries_raw == NULL) {
+		ZEND_ASSERT(array->size == 0);
+		ZEND_ASSERT(array->capacity == 0);
+		ZEND_ASSERT(array->type_tag == LMV_TYPE_UNINITIALIZED);
+		return true;
+	}
+	ZEND_ASSERT((array->entries_zval == empty_entry_list && array->capacity == 0) || array->capacity > 0);
+	return false;
+}
+
+static uint8_t teds_lowmemoryvector_entries_compute_memory_per_element(const teds_lowmemoryvector_entries *array) {
+	ZEND_ASSERT(array->type_tag != LMV_TYPE_UNINITIALIZED);
+	ZEND_ASSERT(array->type_tag < LMV_TYPE_COUNT);
+	return teds_lmv_memory_per_element[array->type_tag];
+}
+
+static void teds_lowmemoryvector_entries_raise_capacity(teds_lowmemoryvector_entries *array, const size_t new_capacity) {
+	ZEND_ASSERT(new_capacity > array->capacity);
+	const uint8_t memory_per_element = teds_lowmemoryvector_entries_compute_memory_per_element(array);
+	if (array->capacity == 0) {
+		array->entries_raw = safe_emalloc(new_capacity, memory_per_element, 0);
+	} else {
+		array->entries_raw = safe_erealloc(array->entries_raw, new_capacity, memory_per_element, 0);
+	}
+	array->capacity = new_capacity;
+	ZEND_ASSERT(array->entries_raw != NULL);
+}
+
+static inline void teds_lowmemoryvector_entries_shrink_capacity(teds_lowmemoryvector_entries *array, size_t size, size_t capacity, void *old_entries_raw) {
+	ZEND_ASSERT(size <= capacity);
+	ZEND_ASSERT(size == array->size);
+	ZEND_ASSERT(capacity > 0);
+	ZEND_ASSERT(capacity < array->capacity);
+	ZEND_ASSERT(old_entries_raw == array->entries_raw);
+	const uint8_t memory_per_element = teds_lowmemoryvector_entries_compute_memory_per_element(array);
+	array->capacity = capacity;
+	array->entries_raw = erealloc2(old_entries_raw, capacity * memory_per_element, size * memory_per_element);
+	ZEND_ASSERT(array->entries_raw != NULL);
+}
+
+/* Initializes the range [from, to) to null. Does not dtor existing entries. */
+/* TODO: Delete if this isn't used in the final version
+static void teds_lowmemoryvector_entries_init_elems(teds_lowmemoryvector_entries *array, zend_long from, zend_long to)
+{
+	ZEND_ASSERT(from <= to);
+	zval *begin = &array->entries[from];
+	zval *end = &array->entries[to];
+
+	while (begin != end) {
+		ZVAL_NULL(begin++);
+	}
+}
+*/
+
+static zend_always_inline void teds_lowmemoryvector_entries_set_empty_list(teds_lowmemoryvector_entries *array) {
+	array->size = 0;
+	array->capacity = 0;
+	array->type_tag = LMV_TYPE_UNINITIALIZED;
+	array->entries_raw = (void *)empty_entry_list;
+}
+
+static void teds_lowmemoryvector_entries_init_from_traversable(teds_lowmemoryvector_entries *array, zend_object *obj)
+{
+	zend_class_entry *ce = obj->ce;
+	zend_object_iterator *iter;
+	size_t size = 0, capacity = 0;
+	array->size = 0;
+	array->entries_raw = NULL;
+	zval *entries = NULL;
+	zval tmp_obj;
+	ZVAL_OBJ(&tmp_obj, obj);
+	iter = ce->get_iterator(ce, &tmp_obj, 0);
+
+	if (UNEXPECTED(EG(exception))) {
+		return;
+	}
+
+	const zend_object_iterator_funcs *funcs = iter->funcs;
+
+	if (funcs->rewind) {
+		funcs->rewind(iter);
+		if (UNEXPECTED(EG(exception))) {
+			return;
+		}
+	}
+
+	/* Reindex keys from 0. */
+	while (funcs->valid(iter) == SUCCESS) {
+		if (EG(exception)) {
+			break;
+		}
+		zval *value = funcs->get_current_data(iter);
+		if (UNEXPECTED(EG(exception))) {
+			break;
+		}
+
+		teds_lowmemoryvector_entries_push(array, value, true);
+
+		iter->index++;
+		funcs->move_forward(iter);
+		if (UNEXPECTED(EG(exception))) {
+			break;
+		}
+	}
+
+	if (iter) {
+		zend_iterator_dtor(iter);
+	}
+}
+
+/* Copies the range [0, n) into the lowmemoryvector, beginning at `offset`.
+ * Does not dtor the existing elements.
+ */
+static void teds_lowmemoryvector_copy_range(teds_lowmemoryvector_entries *array, const int8_t *const start, const size_t n, const uint8_t bytes_per_element)
+{
+	if (array->type_tag <= LMV_TYPE_LAST_NONREFCOUNTED) {
+		memcpy(array->entries_int8, start, bytes_per_element * n);
+		return;
+	}
+	ZEND_ASSERT(array->type_tag == LMV_TYPE_ZVAL);
+	zval *dst = array->entries_zval;
+	const zval *src = (zval *)start;
+	for (zval *end = dst + n; dst < end; dst++, src++) {
+		ZVAL_COPY(dst, src);
+	}
+}
+
+static void teds_lowmemoryvector_entries_copy_ctor(teds_lowmemoryvector_entries *to, const teds_lowmemoryvector_entries *from)
+{
+	zend_long size = from->size;
+	if (!size) {
+		teds_lowmemoryvector_entries_set_empty_list(to);
+		return;
+	}
+
+	to->size = 0; /* reset size in case emalloc() fails */
+	to->capacity = 0;
+	to->type_tag = from->type_tag;
+	const uint8_t bytes_per_element = teds_lowmemoryvector_entries_compute_memory_per_element(from);
+	to->entries_int8 = safe_emalloc(size, bytes_per_element, 0);
+	to->size = size;
+	to->capacity = size;
+
+	teds_lowmemoryvector_copy_range(to, from->entries_int8, size, bytes_per_element);
+}
+
+/* Destructs and frees contents but not the array itself.
+ * If you want to re-use the array then you need to re-initialize it.
+ */
+static void teds_lowmemoryvector_entries_dtor(teds_lowmemoryvector_entries *array)
+{
+	if (!teds_lowmemoryvector_entries_empty_capacity(array)) {
+		zval *entries = array->entries_zval;
+		if (array->type_tag > LMV_TYPE_LAST_NONREFCOUNTED) {
+			ZEND_ASSERT(array->type_tag == LMV_TYPE_ZVAL);
+			zval *it = entries;
+			array->entries_zval = NULL;
+			for (zval *end = it + array->size; it < end; it++) {
+				zval_ptr_dtor(it);
+			}
+		}
+		efree(entries);
+	}
+}
+
+static HashTable* teds_lowmemoryvector_get_gc(zend_object *obj, zval **table, int *n)
+{
+	teds_lowmemoryvector_entries *array = &teds_lowmemoryvector_from_object(obj)->array;
+
+	/* TODO: This won't work with zvals and sizeof size_t > sizeof int with 4 billion values*/
+	size_t len = array->size;
+	if (len == 0 || array->type_tag <= LMV_TYPE_LAST_GC_NO_SIDE_EFFECTS) {
+		*n = 0;
+		return NULL;
+	}
+	ZEND_ASSERT(array->type_tag == LMV_TYPE_ZVAL);
+
+	*n = (int)len;
+	*table = array->entries_zval;
+
+	// Returning the object's properties is redundant if dynamic properties are not allowed,
+	// and this can't be subclassed.
+	return NULL;
+}
+
+static HashTable* teds_lowmemoryvector_get_properties(zend_object *obj)
+{
+	teds_lowmemoryvector_entries *array = &teds_lowmemoryvector_from_object(obj)->array;
+	HashTable *ht = zend_std_get_properties(obj);
+
+	/* Re-initialize properties array */
+
+	// Note that destructors may mutate the original array,
+	// so we fetch the size and circular buffer each time to avoid invalid memory accesses.
+	for (size_t i = 0; i < array->size; i++) {
+		zval tmp;
+		zval *elem = teds_lowmemoryvector_entries_read_offset(array, i, &tmp);
+		Z_TRY_ADDREF_P(elem);
+		zend_hash_index_update(ht, i, elem);
+	}
+	const size_t properties_size = zend_hash_num_elements(ht);
+	if (UNEXPECTED(properties_size > array->size)) {
+		for (size_t i = array->size; i < properties_size; i++) {
+			zend_hash_index_del(ht, i);
+		}
+	}
+
+	return ht;
+}
+
+static void teds_lowmemoryvector_free_storage(zend_object *object)
+{
+	teds_lowmemoryvector *intern = teds_lowmemoryvector_from_object(object);
+	teds_lowmemoryvector_entries_dtor(&intern->array);
+	zend_object_std_dtor(&intern->std);
+}
+
+static zend_object *teds_lowmemoryvector_new_ex(zend_class_entry *class_type, zend_object *orig, bool clone_orig)
+{
+	teds_lowmemoryvector *intern;
+
+	intern = zend_object_alloc(sizeof(teds_lowmemoryvector), class_type);
+	/* This is a final class */
+	ZEND_ASSERT(class_type == teds_ce_LowMemoryVector);
+
+	zend_object_std_init(&intern->std, class_type);
+	object_properties_init(&intern->std, class_type);
+	intern->std.handlers = &teds_handler_LowMemoryVector;
+
+	if (orig && clone_orig) {
+		teds_lowmemoryvector *other = teds_lowmemoryvector_from_object(orig);
+		teds_lowmemoryvector_entries_copy_ctor(&intern->array, &other->array);
+	} else {
+		intern->array.entries_raw = NULL;
+		intern->array.type_tag = LMV_TYPE_UNINITIALIZED;
+	}
+
+	return &intern->std;
+}
+
+static zend_object *teds_lowmemoryvector_new(zend_class_entry *class_type)
+{
+	return teds_lowmemoryvector_new_ex(class_type, NULL, 0);
+}
+
+
+static zend_object *teds_lowmemoryvector_clone(zend_object *old_object)
+{
+	zend_object *new_object = teds_lowmemoryvector_new_ex(old_object->ce, old_object, 1);
+
+	zend_objects_clone_members(new_object, old_object);
+
+	return new_object;
+}
+
+static int teds_lowmemoryvector_count_elements(zend_object *object, zend_long *count)
+{
+	const teds_lowmemoryvector *intern = teds_lowmemoryvector_from_object(object);
+	*count = intern->array.size;
+	return SUCCESS;
+}
+
+/* Get number of entries in this lowmemoryvector */
+PHP_METHOD(Teds_LowMemoryVector, count)
+{
+	zval *object = ZEND_THIS;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	const teds_lowmemoryvector *intern = Z_LOWMEMORYVECTOR_P(object);
+	RETURN_LONG(intern->array.size);
+}
+
+/* Get number of entries in this lowmemoryvector */
+PHP_METHOD(Teds_LowMemoryVector, isEmpty)
+{
+	zval *object = ZEND_THIS;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	const teds_lowmemoryvector *intern = Z_LOWMEMORYVECTOR_P(object);
+	RETURN_BOOL(intern->array.size == 0);
+}
+
+/* Get capacity of this lowmemoryvector */
+PHP_METHOD(Teds_LowMemoryVector, capacity)
+{
+	zval *object = ZEND_THIS;
+
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	const teds_lowmemoryvector *intern = Z_LOWMEMORYVECTOR_P(object);
+	RETURN_LONG(intern->array.capacity);
+}
+
+/* Create this from an optional iterable */
+PHP_METHOD(Teds_LowMemoryVector, __construct)
+{
+	zval *object = ZEND_THIS;
+	zval* iterable = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ITERABLE(iterable)
+	ZEND_PARSE_PARAMETERS_END();
+
+	teds_lowmemoryvector_entries *array = Z_LOWMEMORYVECTOR_ENTRIES_P(object);
+
+	if (UNEXPECTED(!teds_lowmemoryvector_entries_uninitialized(array))) {
+		zend_throw_exception(spl_ce_RuntimeException, "Called Teds\\LowMemoryVector::__construct twice", 0);
+		/* called __construct() twice, bail out */
+		RETURN_THROWS();
+	}
+	uint32_t num_elements;
+	HashTable *values;
+	if (!iterable) {
+		teds_lowmemoryvector_entries_set_empty_list(array);
+		return;
+	}
+
+	switch (Z_TYPE_P(iterable)) {
+		case IS_ARRAY:
+			teds_lowmemoryvector_entries_init_from_array_values(array, Z_ARRVAL_P(iterable));
+			return;
+		case IS_OBJECT:
+			teds_lowmemoryvector_entries_init_from_traversable(array, Z_OBJ_P(iterable));
+			return;
+		EMPTY_SWITCH_DEFAULT_CASE();
+	}
+}
+
+PHP_METHOD(Teds_LowMemoryVector, getIterator)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_create_internal_iterator_zval(return_value, ZEND_THIS);
+}
+
+static void teds_lowmemoryvector_it_dtor(zend_object_iterator *iter)
+{
+	zval_ptr_dtor(&iter->data);
+}
+
+static void teds_lowmemoryvector_it_rewind(zend_object_iterator *iter)
+{
+	((teds_lowmemoryvector_it*)iter)->current = 0;
+}
+
+static int teds_lowmemoryvector_it_valid(zend_object_iterator *iter)
+{
+	teds_lowmemoryvector_it     *iterator = (teds_lowmemoryvector_it*)iter;
+	teds_lowmemoryvector *object   = Z_LOWMEMORYVECTOR_P(&iter->data);
+
+	if (iterator->current >= 0 && ((zend_ulong) iterator->current) < object->array.size) {
+		return SUCCESS;
+	}
+
+	return FAILURE;
+}
+
+
+static zval *teds_lowmemoryvector_it_get_current_data(zend_object_iterator *iter)
+{
+	teds_lowmemoryvector_it *iterator = (teds_lowmemoryvector_it*)iter;
+	teds_lowmemoryvector_entries *array   = Z_LOWMEMORYVECTOR_ENTRIES_P(&iter->data);
+	if (UNEXPECTED(iterator->current >= array->size)) {
+		zend_throw_exception(spl_ce_OutOfBoundsException, "Index out of range", 0);
+		return &EG(uninitialized_zval);
+	}
+	return teds_lowmemoryvector_entries_read_offset(array, iterator->current, &iterator->tmp);
+}
+
+static void teds_lowmemoryvector_it_get_current_key(zend_object_iterator *iter, zval *key)
+{
+	teds_lowmemoryvector_it     *iterator = (teds_lowmemoryvector_it*)iter;
+	teds_lowmemoryvector *object   = Z_LOWMEMORYVECTOR_P(&iter->data);
+
+	size_t offset = iterator->current;
+	if (offset >= object->array.size) {
+		ZVAL_NULL(key);
+	} else {
+		ZVAL_LONG(key, offset);
+	}
+}
+
+static void teds_lowmemoryvector_it_move_forward(zend_object_iterator *iter)
+{
+	((teds_lowmemoryvector_it*)iter)->current++;
+}
+
+/* iterator handler table */
+static const zend_object_iterator_funcs teds_lowmemoryvector_it_funcs = {
+	teds_lowmemoryvector_it_dtor,
+	teds_lowmemoryvector_it_valid,
+	teds_lowmemoryvector_it_get_current_data,
+	teds_lowmemoryvector_it_get_current_key,
+	teds_lowmemoryvector_it_move_forward,
+	teds_lowmemoryvector_it_rewind,
+	NULL,
+	NULL, /* get_gc */
+};
+
+
+zend_object_iterator *teds_lowmemoryvector_get_iterator(zend_class_entry *ce, zval *object, int by_ref)
+{
+	// This is final
+	ZEND_ASSERT(ce == teds_ce_LowMemoryVector);
+	teds_lowmemoryvector_it *iterator;
+
+	if (UNEXPECTED(by_ref)) {
+		zend_throw_error(NULL, "An iterator cannot be used with foreach by reference");
+		return NULL;
+	}
+
+	iterator = emalloc(sizeof(teds_lowmemoryvector_it));
+
+	zend_iterator_init((zend_object_iterator*)iterator);
+
+	ZVAL_OBJ_COPY(&iterator->intern.data, Z_OBJ_P(object));
+	iterator->intern.funcs = &teds_lowmemoryvector_it_funcs;
+
+	return &iterator->intern;
+}
+
+PHP_METHOD(Teds_LowMemoryVector, __unserialize)
+{
+	HashTable *raw_data;
+	zval *val;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &raw_data) == FAILURE) {
+		RETURN_THROWS();
+	}
+	teds_lowmemoryvector_entries *array = Z_LOWMEMORYVECTOR_ENTRIES_P(ZEND_THIS);
+	if (UNEXPECTED(!teds_lowmemoryvector_entries_uninitialized(array))) {
+		zend_throw_exception(spl_ce_RuntimeException, "Already unserialized", 0);
+		RETURN_THROWS();
+	}
+	zend_throw_exception(spl_ce_RuntimeException, "LowMemoryVector __unserialize not yet implemented", 0);
+}
+
+PHP_METHOD(Teds_LowMemoryVector, __serialize)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	zend_throw_exception(spl_ce_RuntimeException, "LowMemoryVector __serialize not yet implemented", 0);
+}
+
+static void teds_lowmemoryvector_entries_init_from_array_values(teds_lowmemoryvector_entries *array, zend_array *raw_data)
+{
+	size_t num_entries = zend_hash_num_elements(raw_data);
+	teds_lowmemoryvector_entries_set_empty_list(array);
+	if (num_entries == 0) {
+		return;
+	}
+	/* TODO: Can probably precompute capacity to avoid reallocations */
+	zval *val;
+	ZEND_HASH_FOREACH_VAL(raw_data, val) {
+		teds_lowmemoryvector_entries_push(array, val, 1);
+	} ZEND_HASH_FOREACH_END();
+}
+
+PHP_METHOD(Teds_LowMemoryVector, __set_state)
+{
+	zend_array *array_ht;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT(array_ht)
+	ZEND_PARSE_PARAMETERS_END();
+	zend_object *object = teds_lowmemoryvector_new(teds_ce_LowMemoryVector);
+	teds_lowmemoryvector *intern = teds_lowmemoryvector_from_object(object);
+	teds_lowmemoryvector_entries_init_from_array_values(&intern->array, array_ht);
+
+	RETURN_OBJ(object);
+}
+
+#ifdef LMV_TYPE_INT64
+#define LMV_GENERATE_INT_CASES() \
+	LMV_INT_CODEGEN(LMV_TYPE_INT8, int8_t,   entries_int8) \
+	LMV_INT_CODEGEN(LMV_TYPE_INT32, int32_t, entries_int32) \
+	LMV_INT_CODEGEN(LMV_TYPE_INT64, int64_t, entries_int64)
+#else
+#define LMV_GENERATE_INT_CASES() \
+	LMV_INT_CODEGEN(LMV_TYPE_INT8, int8_t,   entries_int8) \
+	LMV_INT_CODEGEN(LMV_TYPE_INT32, int32_t, entries_int32)
+#endif
+
+
+PHP_METHOD(Teds_LowMemoryVector, toArray)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+	teds_lowmemoryvector_entries *array = Z_LOWMEMORYVECTOR_ENTRIES_P(ZEND_THIS);
+	size_t len = array->size;
+	if (!len) {
+		RETURN_EMPTY_ARRAY();
+	}
+	zend_array *values = zend_new_array(len);
+	/* Initialize return array */
+	zend_hash_real_init_packed(values);
+
+	/* Go through values and add values to the return array */
+	ZEND_HASH_FILL_PACKED(values) {
+		switch (array->type_tag) {
+			case LMV_TYPE_BOOL_OR_NULL: {
+				const int8_t *const entries = array->entries_uint8;
+				for (size_t i = 0; i < len; i++) {
+					zval tmp;
+					teds_lowmemoryvector_entries_set_type(&tmp, entries[i]);
+					ZEND_HASH_FILL_SET(&tmp);
+					ZEND_HASH_FILL_NEXT();
+				}
+				break;
+			}
+#define LMV_INT_CODEGEN(LMV_TYPE_X, intx_t, entries_intx) \
+			case LMV_TYPE_X: { \
+				const intx_t *const entries = array->entries_intx; \
+				for (size_t i = 0; i < len; i++) { \
+					ZEND_HASH_FILL_SET_LONG(entries[i]); \
+					ZEND_HASH_FILL_NEXT(); \
+				} \
+				break; \
+			}
+LMV_GENERATE_INT_CASES()
+#undef LMV_INT_CODEGEN
+
+			case LMV_TYPE_ZVAL: {
+				zval *entries = array->entries_zval;
+				for (size_t i = 0; i < len; i++) {
+					zval *tmp = &entries[i];
+					Z_TRY_ADDREF_P(tmp);
+					ZEND_HASH_FILL_ADD(tmp);
+				}
+				break;
+			}
+			default:
+				ZEND_UNREACHABLE();
+		}
+	} ZEND_HASH_FILL_END();
+	RETURN_ARR(values);
+}
+
+static zend_always_inline void teds_lowmemoryvector_get_value_at_offset(zval *return_value, const zval *zval_this, zend_long offset)
+{
+	teds_lowmemoryvector_entries *array = Z_LOWMEMORYVECTOR_ENTRIES_P(zval_this);
+	size_t len = array->size;
+	if (UNEXPECTED((zend_ulong) offset >= len)) {
+		zend_throw_exception(spl_ce_OutOfBoundsException, "Index out of range", 0);
+		RETURN_THROWS();
+	}
+	teds_lowmemoryvector_entries_copy_offset(array, offset, return_value, true, false);
+}
+
+PHP_METHOD(Teds_LowMemoryVector, get)
+{
+	zend_long offset;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(offset)
+	ZEND_PARSE_PARAMETERS_END();
+
+	teds_lowmemoryvector_get_value_at_offset(return_value, ZEND_THIS, offset);
+}
+
+PHP_METHOD(Teds_LowMemoryVector, offsetGet)
+{
+	zval *offset_zv;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(offset_zv)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_long offset;
+	CONVERT_OFFSET_TO_LONG_OR_THROW(offset, offset_zv);
+
+	teds_lowmemoryvector_get_value_at_offset(return_value, ZEND_THIS, offset);
+}
+
+PHP_METHOD(Teds_LowMemoryVector, offsetExists)
+{
+	zval *offset_zv;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(offset_zv)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_long offset;
+	CONVERT_OFFSET_TO_LONG_OR_THROW(offset, offset_zv);
+
+	const teds_lowmemoryvector *intern = Z_LOWMEMORYVECTOR_P(ZEND_THIS);
+	const size_t len = intern->array.size;
+	RETURN_BOOL((zend_ulong) offset < len);
+}
+
+PHP_METHOD(Teds_LowMemoryVector, indexOf)
+{
+	zval *value;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	const teds_lowmemoryvector_entries *array = Z_LOWMEMORYVECTOR_ENTRIES_P(ZEND_THIS);
+	const size_t len = array->size;
+	if (len > 0) {
+		switch (array->type_tag) {
+			case LMV_TYPE_BOOL_OR_NULL: {
+				const uint8_t type = Z_TYPE_P(value);
+				if (type > IS_TRUE) {
+					RETURN_NULL();
+				}
+				const uint8_t *start = array->entries_uint8;
+				const uint8_t *it = start;
+				for (const uint8_t *end = it + len; it < end; it++) {
+					if (type == *it) {
+						RETURN_LONG(it - start);
+					}
+				}
+				break;
+			}
+			case LMV_TYPE_INT8: {
+				if (Z_TYPE_P(value) != IS_LONG) {
+					RETURN_NULL();
+				}
+				const int8_t v = (int8_t) Z_LVAL_P(value);
+#if SIZEOF_ZEND_LONG > 4
+				if (v != Z_LVAL_P(value)) { RETURN_NULL(); }
+#endif
+				const int8_t *start = array->entries_int8;
+				const int8_t *it = start;
+				for (const int8_t *end = it + len; it < end; it++) {
+					if (v == *it) {
+						RETURN_LONG(it - start);
+					}
+				}
+				break;
+			}
+			case LMV_TYPE_INT32: {
+				if (Z_TYPE_P(value) != IS_LONG) {
+					RETURN_NULL();
+				}
+				const int32_t v = (int32_t) Z_LVAL_P(value);
+#if SIZEOF_ZEND_LONG > 4
+				if (v != Z_LVAL_P(value)) { RETURN_NULL(); }
+#endif
+				const int32_t *start = array->entries_int32;
+				const int32_t *it = start;
+				for (const int32_t *end = it + len; it < end; it++) {
+					if (v == *it) {
+						RETURN_LONG(it - start);
+					}
+				}
+				break;
+			}
+#ifdef LMV_TYPE_INT64
+			case LMV_TYPE_INT64: {
+				if (Z_TYPE_P(value) != IS_LONG) {
+					RETURN_NULL();
+				}
+				const zend_long v = Z_LVAL_P(value);
+				const int64_t *start = array->entries_int64;
+				const int64_t *it = start;
+				for (const int64_t *end = it + len; it < end; it++) {
+					if (v == *it) {
+						RETURN_LONG(it - start);
+					}
+				}
+				break;
+			}
+#endif
+			case LMV_TYPE_ZVAL: {
+				zval *start = array->entries_zval;
+				zval *it = start;
+				for (zval *end = it + len; it < end; it++) {
+					if (zend_is_identical(value, it)) {
+						RETURN_LONG(it - start);
+					}
+				}
+				break;
+			}
+			default:
+				ZEND_UNREACHABLE();
+		}
+	}
+	RETURN_NULL();
+}
+
+PHP_METHOD(Teds_LowMemoryVector, contains)
+{
+	zval *value;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	const teds_lowmemoryvector_entries *array = Z_LOWMEMORYVECTOR_ENTRIES_P(ZEND_THIS);
+	const size_t len = array->size;
+	if (len > 0) {
+		switch (array->type_tag) {
+			case LMV_TYPE_BOOL_OR_NULL: {
+				const uint8_t type = Z_TYPE_P(value);
+				if (type > IS_TRUE) {
+					RETURN_FALSE;
+				}
+				const uint8_t *start = array->entries_uint8;
+				const uint8_t *it = start;
+				for (const uint8_t *end = it + len; it < end; it++) {
+					if (type == *it) {
+						RETURN_TRUE;
+					}
+				}
+				break;
+			}
+			case LMV_TYPE_INT8: {
+				if (Z_TYPE_P(value) != IS_LONG) {
+					RETURN_FALSE;
+				}
+				const int8_t v = (int8_t) Z_LVAL_P(value);
+#if SIZEOF_ZEND_LONG > 4
+				if (v != Z_LVAL_P(value)) { RETURN_NULL(); }
+#endif
+				const int8_t *start = array->entries_int8;
+				const int8_t *it = start;
+				for (const int8_t *end = it + len; it < end; it++) {
+					if (v == *it) {
+						RETURN_TRUE;
+					}
+				}
+				break;
+			}
+			case LMV_TYPE_INT32: {
+				if (Z_TYPE_P(value) != IS_LONG) {
+					RETURN_FALSE;
+				}
+				const int32_t v = (int32_t) Z_LVAL_P(value);
+#if SIZEOF_ZEND_LONG > 4
+				if (v != Z_LVAL_P(value)) { RETURN_FALSE; }
+#endif
+				const int32_t *start = array->entries_int32;
+				const int32_t *it = start;
+				for (const int32_t *end = it + len; it < end; it++) {
+					if (v == *it) {
+						RETURN_TRUE;
+					}
+				}
+				break;
+			}
+#ifdef LMV_TYPE_INT64
+			case LMV_TYPE_INT64: {
+				if (Z_TYPE_P(value) != IS_LONG) {
+					RETURN_FALSE;
+				}
+				const zend_long v = Z_LVAL_P(value);
+				const int64_t *it = array->entries_int64;
+				for (const int64_t *end = it + len; it < end; it++) {
+					if (v == *it) {
+						RETURN_TRUE;
+					}
+				}
+				break;
+			}
+#endif
+			case LMV_TYPE_ZVAL: {
+				zval *it = array->entries_zval;
+				for (zval *end = it + len; it < end; it++) {
+					if (zend_is_identical(value, it)) {
+						RETURN_TRUE;
+					}
+				}
+				break;
+			}
+			default:
+				ZEND_UNREACHABLE();
+		}
+	}
+	RETURN_FALSE;
+}
+
+static zend_always_inline void teds_lowmemoryvector_set_value_at_offset(zend_object *object, zend_long offset, zval *value) {
+	teds_lowmemoryvector_entries *array = &teds_lowmemoryvector_from_object(object)->array;
+	teds_lowmemoryvector_entries_update_type_tag(array, value);
+	size_t len = array->size;
+	if (UNEXPECTED((zend_ulong) offset >= len)) {
+		zend_throw_exception(spl_ce_OutOfBoundsException, "Index out of range", 0);
+		return;
+	}
+	switch (array->type_tag) {
+		case LMV_TYPE_BOOL_OR_NULL: {
+			array->entries_uint8[offset] = teds_lowmemoryvector_entries_get_type(value);
+			break;
+		}
+#define LMV_INT_CODEGEN(LMV_TYPE_X, intx_t, entries_intx) \
+		case LMV_TYPE_X: \
+			ZEND_ASSERT(Z_TYPE_P(value) == IS_LONG); \
+			array->entries_intx[offset] = Z_LVAL_P(value); \
+			break;
+LMV_GENERATE_INT_CASES()
+#undef LMV_INT_CODEGEN
+
+		case LMV_TYPE_ZVAL: {
+			zval tmp;
+			zval *dst = &array->entries_zval[offset];
+			ZVAL_COPY_VALUE(&tmp, dst);
+			ZVAL_COPY(dst, value);
+			/* Garbage collect original value after modifying to avoid writing to invalid location due to side effects of destructor */
+			zval_ptr_dtor(&tmp);
+			break;
+		}
+		default:
+			ZEND_UNREACHABLE();
+	}
+}
+
+PHP_METHOD(Teds_LowMemoryVector, set)
+{
+	zend_long offset;
+	zval *value;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(offset)
+		Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	teds_lowmemoryvector_set_value_at_offset(Z_OBJ_P(ZEND_THIS), offset, value);
+	TEDS_RETURN_VOID();
+}
+
+PHP_METHOD(Teds_LowMemoryVector, offsetSet)
+{
+	zval                  *offset_zv, *value;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(offset_zv)
+		Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_long offset;
+	CONVERT_OFFSET_TO_LONG_OR_THROW(offset, offset_zv);
+
+	teds_lowmemoryvector_set_value_at_offset(Z_OBJ_P(ZEND_THIS), offset, value);
+	TEDS_RETURN_VOID();
+}
+
+static zend_always_inline void teds_lowmemoryvector_entries_copy_offset(const teds_lowmemoryvector_entries *array, const zend_ulong offset, zval *dst, bool increase_refcount, bool pop)
+{
+	ZEND_ASSERT(pop ? array->size < array->capacity : array->size <= array->capacity);
+	ZEND_ASSERT(pop ? offset == array->size : offset < array->size);
+	ZEND_ASSERT(dst != NULL);
+
+	switch (array->type_tag) {
+		case LMV_TYPE_BOOL_OR_NULL: teds_lowmemoryvector_entries_set_type(dst, array->entries_uint8[offset]); return;
+
+#define LMV_INT_CODEGEN(LMV_TYPE_X, intx_t, entries_intx) \
+		case LMV_TYPE_X: ZVAL_LONG(dst, array->entries_intx[offset]); return;
+LMV_GENERATE_INT_CASES();
+#undef LMV_INT_CODEGEN
+
+		case LMV_TYPE_ZVAL:
+			if (increase_refcount) {
+				ZVAL_COPY(dst, &array->entries_zval[offset]);
+			} else {
+				ZVAL_COPY_VALUE(dst, &array->entries_zval[offset]);
+			}
+			return;
+		default:
+			ZEND_UNREACHABLE();
+	}
+}
+
+static zend_always_inline zval *teds_lowmemoryvector_entries_read_offset(const teds_lowmemoryvector_entries *const array, const zend_ulong offset, zval *const tmp)
+{
+	ZEND_ASSERT(array->size <= array->capacity);
+	ZEND_ASSERT(offset < array->size);
+	ZEND_ASSERT(tmp != NULL);
+
+	switch (array->type_tag) {
+		case LMV_TYPE_BOOL_OR_NULL: teds_lowmemoryvector_entries_set_type(tmp, array->entries_uint8[offset]); return tmp;
+
+#define LMV_INT_CODEGEN(LMV_TYPE_X, intx_t, entries_intx) \
+		case LMV_TYPE_X: ZVAL_LONG(tmp, array->entries_intx[offset]); return tmp;
+LMV_GENERATE_INT_CASES();
+#undef LMV_INT_CODEGEN
+
+		case LMV_TYPE_ZVAL:
+			return &array->entries_zval[offset];
+		default:
+			ZEND_UNREACHABLE();
+	}
+}
+
+static zend_always_inline void teds_lowmemoryvector_entries_update_type_tag(teds_lowmemoryvector_entries *array, const zval *val)
+{
+
+#define TEDS_PROMOTE_INT_TYPE(int_smaller, entries_smaller, int_larger, entries_larger, LMV_TYPE_LARGER) \
+	array->type_tag = LMV_TYPE_LARGER; \
+	int_smaller *const original_entries = array->entries_smaller; \
+	const int_smaller *src = original_entries; \
+	const size_t size = array->size; \
+	const size_t capacity = size >= 2 ? size * 2 : 4; \
+	array->capacity = capacity; \
+	int_larger *const entries_larger  = safe_emalloc(capacity, sizeof(int_larger), 0); \
+	const int_larger *const end = entries_larger + size; \
+	int_larger *dst = entries_larger; \
+	array->entries_larger = entries_larger; \
+	while (dst < end) { \
+		*dst++ = *src++; \
+	} \
+	if (array->capacity > 0) { \
+		efree(original_entries); \
+	}
+
+#define TEDS_CHECK_PROMOTE_INT_TO_ZVAL(intx_t, entries_intx) \
+	if (Z_TYPE_P(val) != IS_LONG) { \
+		array->type_tag = LMV_TYPE_ZVAL; \
+		intx_t *const original_entries = array->entries_intx; \
+		const intx_t *src = original_entries; \
+		const size_t size = array->size; \
+		const size_t capacity = size >= 2 ? size * 2 : 4; \
+		array->capacity = capacity; \
+		zval *const entries_zval = safe_emalloc(capacity, sizeof(zval), 0); \
+		const zval *const end = entries_zval + size; \
+		zval *dst = entries_zval; \
+		array->entries_zval = entries_zval; \
+		for (; dst < end; dst++, src++) { \
+			ZVAL_LONG(dst, *src); \
+		} \
+		if (array->capacity > 0) { \
+			efree(original_entries); \
+		} \
+		return; \
+	}
+
+
+	ZEND_ASSERT(Z_TYPE_P(val) >= IS_NULL && Z_TYPE_P(val) <= IS_RESOURCE);
+	switch (array->type_tag) {
+		case LMV_TYPE_UNINITIALIZED:
+			ZEND_ASSERT(teds_lowmemoryvector_entries_empty_capacity(array));
+			switch (Z_TYPE_P(val)) {
+				case IS_NULL:
+				case IS_FALSE:
+				case IS_TRUE:
+					array->type_tag = LMV_TYPE_BOOL_OR_NULL;
+					return;
+				case IS_LONG: {
+					if (Z_LVAL_P(val) != (int8_t)Z_LVAL_P(val)) {
+#ifdef LMV_TYPE_INT64
+						if (Z_LVAL_P(val) != (int32_t)Z_LVAL_P(val)) {
+							array->type_tag = LMV_TYPE_INT64;
+							return;
+						}
+#endif
+						array->type_tag = LMV_TYPE_INT32;
+						return;
+					}
+					array->type_tag = LMV_TYPE_INT8;
+					return;
+				}
+				default:
+					array->type_tag = LMV_TYPE_ZVAL;
+					return;
+			}
+		case LMV_TYPE_BOOL_OR_NULL:
+			if (Z_TYPE_P(val) > IS_TRUE) {
+				array->type_tag = LMV_TYPE_ZVAL;
+				uint8_t *const original_types = array->entries_uint8;
+				const uint8_t *src = original_types;
+				const size_t size = array->size;
+				const size_t capacity = size >= 2 ? size * 2 : 4;
+				array->capacity = capacity;
+				zval *const entries_zval = safe_emalloc(capacity, sizeof(zval), 0);
+				const zval *const end = entries_zval + size;
+				zval *dst = entries_zval;
+				array->entries_zval = entries_zval;
+				for (; dst < end; dst++, src++) {
+					teds_lowmemoryvector_entries_set_type(dst, *src);
+				}
+				if (array->capacity > 0) {
+					efree(original_types);
+				}
+				return;
+			}
+			return;
+		case LMV_TYPE_INT8:
+
+			TEDS_CHECK_PROMOTE_INT_TO_ZVAL(int8_t, entries_int8)
+
+			if (Z_LVAL_P(val) != (int8_t) Z_LVAL_P(val)) {
+#ifdef LMV_TYPE_INT64
+				if (Z_LVAL_P(val) != (int32_t) Z_LVAL_P(val)) {
+					TEDS_PROMOTE_INT_TYPE(int8_t, entries_int8, int64_t, entries_int64, LMV_TYPE_INT64);
+					return;
+				}
+#endif
+				TEDS_PROMOTE_INT_TYPE(int8_t, entries_int8, int32_t, entries_int32, LMV_TYPE_INT32);
+			}
+			return;
+		case LMV_TYPE_INT32:
+			TEDS_CHECK_PROMOTE_INT_TO_ZVAL(int32_t, entries_int32)
+
+#ifdef LMV_TYPE_INT64
+			if (Z_LVAL_P(val) != (int32_t) Z_LVAL_P(val)) {
+				TEDS_PROMOTE_INT_TYPE(int32_t, entries_int32, int64_t, entries_int64, LMV_TYPE_INT64);
+			}
+#endif
+			return;
+#ifdef LMV_TYPE_INT64
+		case LMV_TYPE_INT64:
+			TEDS_CHECK_PROMOTE_INT_TO_ZVAL(int64_t, entries_int64)
+			return;
+#endif
+
+#undef TEDS_PROMOTE_INT_TYPE
+		case LMV_TYPE_ZVAL:
+			/* This can hold any type */
+			return;
+		default:
+			ZEND_UNREACHABLE();
+	}
+}
+
+static zend_always_inline void teds_lowmemoryvector_entries_push(teds_lowmemoryvector_entries *array, const zval *value, const bool check_capacity)
+{
+	const size_t old_size = array->size;
+	teds_lowmemoryvector_entries_update_type_tag(array, value);
+	/* update_type_tag may raise the capacity */
+	const size_t old_capacity = array->capacity;
+
+	if (check_capacity) {
+		if (old_size >= old_capacity) {
+			ZEND_ASSERT(old_size == old_capacity);
+			teds_lowmemoryvector_entries_raise_capacity(array, old_size > 2 ? old_size * 2 : 4);
+		}
+	} else {
+		ZEND_ASSERT(old_size < old_capacity);
+	}
+	switch (array->type_tag) {
+		case LMV_TYPE_BOOL_OR_NULL: \
+			array->entries_uint8[old_size] = teds_lowmemoryvector_entries_get_type(value);
+			break;
+#define LMV_INT_CODEGEN(LMV_TYPE_X, intx_t, entries_intx) \
+		case LMV_TYPE_X: \
+			ZEND_ASSERT(Z_TYPE_P(value) == IS_LONG); \
+			array->entries_intx[old_size] = Z_LVAL_P(value); \
+			break;
+LMV_GENERATE_INT_CASES()
+#undef LMV_INT_CODEGEN
+
+		case LMV_TYPE_ZVAL:
+			ZVAL_COPY(&array->entries_zval[old_size], value);
+			break;
+		default:
+			ZEND_UNREACHABLE();
+	}
+	array->size++;
+}
+
+/* Based on array_push */
+PHP_METHOD(Teds_LowMemoryVector, push)
+{
+	const zval *args;
+	uint32_t argc;
+
+	ZEND_PARSE_PARAMETERS_START(0, -1)
+		Z_PARAM_VARIADIC('+', args, argc)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (UNEXPECTED(argc == 0)) {
+		return;
+	}
+	teds_lowmemoryvector_entries *array = Z_LOWMEMORYVECTOR_ENTRIES_P(ZEND_THIS);
+	const size_t old_size = array->size;
+	const size_t new_size = old_size + argc;
+	/* The compiler will type check but eliminate dead code on platforms where size_t is 32 bits (4 bytes) */
+	if (SIZEOF_SIZE_T < 8 && UNEXPECTED(new_size > MAX_VALID_OFFSET + 1 || new_size < old_size)) {
+		teds_error_noreturn_max_lowmemoryvector_capacity();
+		ZEND_UNREACHABLE();
+	}
+
+	for (uint32_t i = 0; i < argc; i++) {
+		teds_lowmemoryvector_entries_push(array, &args[i], true);
+	}
+	array->size = new_size;
+	TEDS_RETURN_VOID();
+}
+
+PHP_METHOD(Teds_LowMemoryVector, pop)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	teds_lowmemoryvector_entries *array = Z_LOWMEMORYVECTOR_ENTRIES_P(ZEND_THIS);
+	const size_t old_size = array->size;
+	if (old_size == 0) {
+		zend_throw_exception(spl_ce_UnderflowException, "Cannot pop from empty Teds\\LowMemoryVector", 0);
+		RETURN_THROWS();
+	}
+	const size_t old_capacity = array->capacity;
+	array->size--;
+	teds_lowmemoryvector_entries_copy_offset(array, array->size, return_value, false, true);
+	if (old_size * 4 < old_capacity) {
+		/* Shrink the storage if only a quarter of the capacity is used  */
+		const size_t size = old_size - 1;
+		const size_t capacity = size > 2 ? size * 2 : 4;
+		if (capacity < old_capacity) {
+			teds_lowmemoryvector_entries_shrink_capacity(array, size, capacity, array->entries_raw);
+		}
+	}
+}
+
+PHP_METHOD(Teds_LowMemoryVector, offsetUnset)
+{
+	zval                  *offset_zv;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &offset_zv) == FAILURE) {
+		RETURN_THROWS();
+	}
+	zend_throw_exception(spl_ce_RuntimeException, "Teds\\LowMemoryVector does not support offsetUnset - elements must be set to null or removed by resizing", 0);
+	RETURN_THROWS();
+}
+
+static void teds_lowmemoryvector_write_dimension(zend_object *object, zval *offset_zv, zval *value)
+{
+	teds_lowmemoryvector *intern = teds_lowmemoryvector_from_object(object);
+	if (!offset_zv) {
+		teds_lowmemoryvector_entries_push(&intern->array, value, true);
+		return;
+	}
+
+	zend_long offset;
+	CONVERT_OFFSET_TO_LONG_OR_THROW(offset, offset_zv);
+
+	if (offset < 0 || (zend_ulong) offset >= intern->array.size) {
+		zend_throw_exception(spl_ce_OutOfBoundsException, "Index invalid or out of range", 0);
+		return;
+	}
+	ZVAL_DEREF(value);
+	teds_lowmemoryvector_set_value_at_offset(object, offset, value);
+}
+
+static zval *teds_lowmemoryvector_read_dimension(zend_object *object, zval *offset_zv, int type, zval *rv)
+{
+	if (UNEXPECTED(!offset_zv || Z_ISUNDEF_P(offset_zv))) {
+		return &EG(uninitialized_zval);
+	}
+
+	zend_long offset;
+	CONVERT_OFFSET_TO_LONG_OR_THROW_RETURN_NULLPTR(offset, offset_zv);
+
+	const teds_lowmemoryvector_entries *array = &teds_lowmemoryvector_from_object(object)->array;
+
+	if (UNEXPECTED(offset < 0 || (zend_ulong) offset >= array->size)) {
+		if (type != BP_VAR_IS) {
+			zend_throw_exception(spl_ce_OutOfBoundsException, "Index out of range", 0);
+		}
+		return NULL;
+	} else {
+		return teds_lowmemoryvector_entries_read_offset(array, offset, rv);
+	}
+}
+
+static int teds_lowmemoryvector_has_dimension(zend_object *object, zval *offset_zv, int check_empty)
+{
+	zend_long offset;
+	if (UNEXPECTED(Z_TYPE_P(offset_zv) != IS_LONG)) {
+		offset = teds_get_offset(offset_zv);
+		if (UNEXPECTED(EG(exception))) {
+			return 0;
+		}
+	} else {
+		offset = Z_LVAL_P(offset_zv);
+	}
+
+	const teds_lowmemoryvector_entries *array = &teds_lowmemoryvector_from_object(object)->array;
+
+	if (UNEXPECTED(((zend_ulong) offset) >= array->size || offset < 0)) {
+		return 0;
+	}
+
+	/* TODO can optimize */
+	zval tmp;
+	zval *val = teds_lowmemoryvector_entries_read_offset(array, offset, &tmp);
+	if (check_empty) {
+		return zend_is_true(val);
+	}
+	return Z_TYPE_P(val) != IS_NULL;
+}
+
+PHP_MINIT_FUNCTION(teds_lowmemoryvector)
+{
+	TEDS_MINIT_IGNORE_UNUSED();
+	teds_ce_LowMemoryVector = register_class_Teds_LowMemoryVector(zend_ce_aggregate, zend_ce_countable, php_json_serializable_ce, zend_ce_arrayaccess);
+	teds_ce_LowMemoryVector->create_object = teds_lowmemoryvector_new;
+
+	memcpy(&teds_handler_LowMemoryVector, &std_object_handlers, sizeof(zend_object_handlers));
+
+	teds_handler_LowMemoryVector.offset          = XtOffsetOf(teds_lowmemoryvector, std);
+	teds_handler_LowMemoryVector.clone_obj       = teds_lowmemoryvector_clone;
+	teds_handler_LowMemoryVector.count_elements  = teds_lowmemoryvector_count_elements;
+	teds_handler_LowMemoryVector.get_properties  = teds_lowmemoryvector_get_properties;
+	teds_handler_LowMemoryVector.get_gc          = teds_lowmemoryvector_get_gc;
+	teds_handler_LowMemoryVector.free_obj        = teds_lowmemoryvector_free_storage;
+
+	teds_handler_LowMemoryVector.read_dimension  = teds_lowmemoryvector_read_dimension;
+	teds_handler_LowMemoryVector.write_dimension = teds_lowmemoryvector_write_dimension;
+	teds_handler_LowMemoryVector.has_dimension   = teds_lowmemoryvector_has_dimension;
+
+	teds_ce_LowMemoryVector->ce_flags |= ZEND_ACC_FINAL | ZEND_ACC_NO_DYNAMIC_PROPERTIES;
+	teds_ce_LowMemoryVector->get_iterator = teds_lowmemoryvector_get_iterator;
+
+	return SUCCESS;
+}

--- a/teds_lowmemoryvector.h
+++ b/teds_lowmemoryvector.h
@@ -1,0 +1,17 @@
+/*
+  +----------------------------------------------------------------------+
+  | teds extension for PHP                                               |
+  | See COPYING file for further copyright information                   |
+  +----------------------------------------------------------------------+
+  | Author: Tyson Andre <tandre@php.net>                                 |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef TEDS_LOWMEMORYVECTOR_H
+#define TEDS_LOWMEMORYVECTOR_H
+
+extern zend_class_entry *teds_ce_LowMemoryVector;
+
+PHP_MINIT_FUNCTION(teds_lowmemoryvector);
+
+#endif	/* TEDS_LOWMEMORYVECTOR_H */

--- a/teds_lowmemoryvector.stub.php
+++ b/teds_lowmemoryvector.stub.php
@@ -1,0 +1,94 @@
+<?php
+
+/** @generate-class-entries */
+
+namespace Teds;
+
+/**
+ * A LowMemoryVector is a container of a sequence of values (with keys 0, 1, ...count($vector) - 1)
+ * that can change in size.
+ *
+ * This is backed by a memory-efficient representation
+ * (raw array of values) and provides fast access (compared to other objects in the Spl)
+ * and constant amortized-time push/pop operations.
+ *
+ * Attempting to read or write values outside of the range of values with `*get`/`*set` methods will throw at runtime.
+ */
+final class LowMemoryVector implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+{
+    /**
+     * Construct a LowMemoryVector from an iterable.
+     *
+     * The keys will be ignored, and values will be reindexed without gaps starting from 0
+     */
+    public function __construct(iterable $iterator = []) {}
+    /**
+     * Returns an iterator that will return the indexes and values of iterable until index >= count()
+     */
+    public function getIterator(): \InternalIterator {}
+    /**
+     * Returns the number of values in this LowMemoryVector
+     */
+    public function count(): int {}
+    /**
+     * Returns whether this vector is empty (has a count of 0)
+     */
+    public function isEmpty(): bool {}
+    /**
+     * Returns the total capacity of this LowMemoryVector.
+     */
+    public function capacity(): int {}
+
+    /**
+     * FIXME finalize implementation before enabling serialization
+     */
+    public function __serialize(): array {}
+    public function __unserialize(array $data): void {}
+
+    /** Create this from an array */
+    public static function __set_state(array $array): LowMemoryVector {}
+
+    public function push(mixed ...$values): void {}
+    public function pop(): mixed {}
+
+    public function toArray(): array {}
+    // Strictly typed, unlike offsetGet/offsetSet
+    public function get(int $offset): mixed {}
+    public function set(int $offset, mixed $value): void {}
+
+    /**
+     * Returns the value at (int)$offset.
+     * @throws \OutOfBoundsException if the value of (int)$offset is not within the bounds of this vector
+     */
+    public function offsetGet(mixed $offset): mixed {}
+
+    /**
+     * Returns true if `0 <= (int)$offset && (int)$offset < $this->count().
+     */
+    public function offsetExists(mixed $offset): bool {}
+
+    /**
+     * Sets the value at offset (int)$offset to $value
+     * @throws \OutOfBoundsException if the value of (int)$offset is not within the bounds of this vector
+     */
+    public function offsetSet(mixed $offset, mixed $value): void {}
+
+    /**
+     * @throws \RuntimeException unconditionally because unset and null are different things, unlike SplFixedArray
+     */
+    public function offsetUnset(mixed $offset): void {}
+
+    /**
+     * Returns the offset of a value that is === $value, or returns null.
+     */
+    public function indexOf(mixed $value): ?int {}
+    /**
+     * Returns true if there exists a value === $value in this vector.
+     */
+    public function contains(mixed $value): bool {}
+
+    /**
+     * @implementation-alias Teds\LowMemoryVector::toArray
+     */
+    public function jsonSerialize(): array {}
+}

--- a/teds_lowmemoryvector_arginfo.h
+++ b/teds_lowmemoryvector_arginfo.h
@@ -1,0 +1,131 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 81955c2e86b0f342bb3db50094766943f3137bc3 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_LowMemoryVector___construct, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_LowMemoryVector_getIterator, 0, 0, InternalIterator, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_isEmpty, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_LowMemoryVector_capacity arginfo_class_Teds_LowMemoryVector_count
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector___serialize, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector___unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_LowMemoryVector___set_state, 0, 1, Teds\\LowMemoryVector, 0)
+	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_push, 0, 0, IS_VOID, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, values, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_pop, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_LowMemoryVector_toArray arginfo_class_Teds_LowMemoryVector___serialize
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_get, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_set, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_offsetGet, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_offsetExists, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_offsetSet, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_offsetUnset, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_indexOf, 0, 1, IS_LONG, 1)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_contains, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_LowMemoryVector_jsonSerialize arginfo_class_Teds_LowMemoryVector___serialize
+
+
+ZEND_METHOD(Teds_LowMemoryVector, __construct);
+ZEND_METHOD(Teds_LowMemoryVector, getIterator);
+ZEND_METHOD(Teds_LowMemoryVector, count);
+ZEND_METHOD(Teds_LowMemoryVector, isEmpty);
+ZEND_METHOD(Teds_LowMemoryVector, capacity);
+ZEND_METHOD(Teds_LowMemoryVector, __serialize);
+ZEND_METHOD(Teds_LowMemoryVector, __unserialize);
+ZEND_METHOD(Teds_LowMemoryVector, __set_state);
+ZEND_METHOD(Teds_LowMemoryVector, push);
+ZEND_METHOD(Teds_LowMemoryVector, pop);
+ZEND_METHOD(Teds_LowMemoryVector, toArray);
+ZEND_METHOD(Teds_LowMemoryVector, get);
+ZEND_METHOD(Teds_LowMemoryVector, set);
+ZEND_METHOD(Teds_LowMemoryVector, offsetGet);
+ZEND_METHOD(Teds_LowMemoryVector, offsetExists);
+ZEND_METHOD(Teds_LowMemoryVector, offsetSet);
+ZEND_METHOD(Teds_LowMemoryVector, offsetUnset);
+ZEND_METHOD(Teds_LowMemoryVector, indexOf);
+ZEND_METHOD(Teds_LowMemoryVector, contains);
+
+
+static const zend_function_entry class_Teds_LowMemoryVector_methods[] = {
+	ZEND_ME(Teds_LowMemoryVector, __construct, arginfo_class_Teds_LowMemoryVector___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, getIterator, arginfo_class_Teds_LowMemoryVector_getIterator, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, count, arginfo_class_Teds_LowMemoryVector_count, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, isEmpty, arginfo_class_Teds_LowMemoryVector_isEmpty, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, capacity, arginfo_class_Teds_LowMemoryVector_capacity, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, __serialize, arginfo_class_Teds_LowMemoryVector___serialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, __unserialize, arginfo_class_Teds_LowMemoryVector___unserialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, __set_state, arginfo_class_Teds_LowMemoryVector___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Teds_LowMemoryVector, push, arginfo_class_Teds_LowMemoryVector_push, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, pop, arginfo_class_Teds_LowMemoryVector_pop, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, toArray, arginfo_class_Teds_LowMemoryVector_toArray, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, get, arginfo_class_Teds_LowMemoryVector_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, set, arginfo_class_Teds_LowMemoryVector_set, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, offsetGet, arginfo_class_Teds_LowMemoryVector_offsetGet, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, offsetExists, arginfo_class_Teds_LowMemoryVector_offsetExists, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, offsetSet, arginfo_class_Teds_LowMemoryVector_offsetSet, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, offsetUnset, arginfo_class_Teds_LowMemoryVector_offsetUnset, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, indexOf, arginfo_class_Teds_LowMemoryVector_indexOf, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, contains, arginfo_class_Teds_LowMemoryVector_contains, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_LowMemoryVector, jsonSerialize, toArray, arginfo_class_Teds_LowMemoryVector_jsonSerialize, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_Teds_LowMemoryVector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Teds", "LowMemoryVector", class_Teds_LowMemoryVector_methods);
+	class_entry = zend_register_internal_class_ex(&ce, NULL);
+	class_entry->ce_flags |= ZEND_ACC_FINAL;
+	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+
+	return class_entry;
+}

--- a/tests/LowMemoryVector/Vector.phpt
+++ b/tests/LowMemoryVector/Vector.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Teds\LowMemoryVector constructed from array
+--FILE--
+<?php
+// discards keys
+$it = new Teds\LowMemoryVector(['first' => 'x', 'second' => new stdClass()]);
+foreach ($it as $key => $value) {
+    printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
+}
+var_dump($it);
+var_dump((array)$it);
+
+$it = new Teds\LowMemoryVector([]);
+var_dump($it);
+var_dump((array)$it);
+foreach ($it as $key => $value) {
+    echo "Unreachable\n";
+}
+
+// Teds\LowMemoryVector will always reindex keys in the order of iteration, like array_values() does.
+$it = new Teds\LowMemoryVector([2 => 'a', 0 => 'b']);
+var_dump($it);
+
+var_dump(new Teds\LowMemoryVector([-1 => new stdClass()]));
+?>
+--EXPECT--
+Key: 0
+Value: 'x'
+Key: 1
+Value: (object) array(
+)
+object(Teds\LowMemoryVector)#1 (2) {
+  [0]=>
+  string(1) "x"
+  [1]=>
+  object(stdClass)#2 (0) {
+  }
+}
+array(2) {
+  [0]=>
+  string(1) "x"
+  [1]=>
+  object(stdClass)#2 (0) {
+  }
+}
+object(Teds\LowMemoryVector)#3 (0) {
+}
+array(0) {
+}
+object(Teds\LowMemoryVector)#1 (2) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "b"
+}
+object(Teds\LowMemoryVector)#3 (1) {
+  [0]=>
+  object(stdClass)#4 (0) {
+  }
+}

--- a/tests/LowMemoryVector/aggregate.phpt
+++ b/tests/LowMemoryVector/aggregate.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Teds\LowMemoryVector is an IteratorAggregate
+--FILE--
+<?php
+
+$vector = new Teds\LowMemoryVector(['x', (object)['key' => 'value']]);
+foreach ($vector as $k => $v) {
+    foreach ($vector as $k2 => $v2) {
+        printf("k=%s k2=%s v=%s v2=%s\n", json_encode($k), json_encode($k2), json_encode($v), json_encode($v2));
+    }
+}
+?>
+--EXPECT--
+k=0 k2=0 v="x" v2="x"
+k=0 k2=1 v="x" v2={"key":"value"}
+k=1 k2=0 v={"key":"value"} v2="x"
+k=1 k2=1 v={"key":"value"} v2={"key":"value"}

--- a/tests/LowMemoryVector/arrayCast.phpt
+++ b/tests/LowMemoryVector/arrayCast.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Teds\LowMemoryVector to array
+--FILE--
+<?php
+// discards keys
+$it = new Teds\LowMemoryVector([strtoupper('test')]);
+var_dump((array)$it);
+$it[0] = strtoupper('test2');
+var_dump((array)$it);
+var_dump($it);
+$it->pop();
+var_dump($it);
+
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(4) "TEST"
+}
+array(1) {
+  [0]=>
+  string(5) "TEST2"
+}
+object(Teds\LowMemoryVector)#1 (1) {
+  [0]=>
+  string(5) "TEST2"
+}
+object(Teds\LowMemoryVector)#1 (0) {
+}

--- a/tests/LowMemoryVector/clone.phpt
+++ b/tests/LowMemoryVector/clone.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Teds\LowMemoryVector can be cloned
+--FILE--
+<?php
+
+$it = new Teds\LowMemoryVector([new stdClass(), new ArrayObject()]);
+$it2 = clone $it;
+unset($it);
+foreach ($it2 as $key => $value) {
+    echo "Saw entry:\n";
+    var_dump($key, $value);
+}
+
+?>
+--EXPECT--
+Saw entry:
+int(0)
+object(stdClass)#2 (0) {
+}
+Saw entry:
+int(1)
+object(ArrayObject)#3 (1) {
+  ["storage":"ArrayObject":private]=>
+  array(0) {
+  }
+}

--- a/tests/LowMemoryVector/contains.phpt
+++ b/tests/LowMemoryVector/contains.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Teds\LowMemoryVector contains()/indexOf();
+--FILE--
+<?php
+// Use strtolower to create values that must be garbage collected
+$o = new stdClass();
+$it = new Teds\LowMemoryVector(['first', $o, 'first']);
+foreach ([null, 'o', $o, new stdClass(), strtolower('FIRST')] as $value) {
+    printf("%s: contains=%s, indexOf=%s\n", json_encode($value), json_encode($it->contains($value)), json_encode($it->indexOf($value)));
+}
+?>
+--EXPECT--
+null: contains=false, indexOf=null
+"o": contains=false, indexOf=null
+{}: contains=true, indexOf=1
+{}: contains=false, indexOf=null
+"first": contains=true, indexOf=0

--- a/tests/LowMemoryVector/exceptionhandler.phpt
+++ b/tests/LowMemoryVector/exceptionhandler.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Teds\LowMemoryVector constructed from Traversable throwing
+--FILE--
+<?php
+
+class HasDestructor {
+    public function __construct(public string $value) {}
+    public function __destruct() {
+        echo "in " . __METHOD__ . " $this->value\n";
+    }
+}
+
+function yields_and_throws() {
+    yield 123 => new HasDestructor('in value');
+    yield new HasDestructor('in key') => 123;
+    yield 123 => new HasDestructor('in value');
+    yield 'first' => 'second';
+
+    throw new RuntimeException('test');
+
+    echo "Unreachable\n";
+}
+try {
+    $it = new Teds\LowMemoryVector(yields_and_throws());
+} catch (RuntimeException $e) {
+    echo "Caught " . $e->getMessage() . "\n";
+}
+gc_collect_cycles();
+echo "Done\n";
+?>
+--EXPECT--
+in HasDestructor::__destruct in key
+in HasDestructor::__destruct in value
+in HasDestructor::__destruct in value
+Caught test
+Done

--- a/tests/LowMemoryVector/isEmpty.phpt
+++ b/tests/LowMemoryVector/isEmpty.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Teds\LowMemoryVector isEmpty()
+--FILE--
+<?php
+// discards keys
+var_dump((new Teds\LowMemoryVector())->isEmpty());
+var_dump((new Teds\LowMemoryVector([]))->isEmpty());
+var_dump((new Teds\LowMemoryVector([false]))->isEmpty());
+var_dump((new Teds\LowMemoryVector([1,2,3,4]))->isEmpty());
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(false)
+bool(false)

--- a/tests/LowMemoryVector/isset.phpt
+++ b/tests/LowMemoryVector/isset.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Teds\LowMemoryVector isset
+--FILE--
+<?php
+$it = new Teds\LowMemoryVector([null, false, new stdClass()]);
+foreach ([0, 1, 2, 3, -1, '1', PHP_INT_MIN, PHP_INT_MAX, 1.0, false, true] as $offset) {
+    printf("offset=%s isset=%s empty=%s value=%s\n", json_encode($offset), json_encode(isset($it[$offset])), json_encode(empty($it[$offset])), json_encode($it[$offset] ?? null));
+}
+?>
+--EXPECTF--
+offset=0 isset=false empty=true value=null
+offset=1 isset=true empty=true value=false
+offset=2 isset=true empty=false value={}
+offset=3 isset=false empty=true value=null
+offset=-1 isset=false empty=true value=null
+offset="1" isset=true empty=true value=false
+offset=-%d isset=false empty=true value=null
+offset=%d isset=false empty=true value=null
+offset=1 isset=true empty=true value=false
+offset=false isset=false empty=true value=null
+offset=true isset=true empty=true value=false

--- a/tests/LowMemoryVector/offsetGet.phpt
+++ b/tests/LowMemoryVector/offsetGet.phpt
@@ -1,0 +1,80 @@
+--TEST--
+Teds\LowMemoryVector offsetGet/get
+--FILE--
+<?php
+
+function expect_throws(Closure $cb): void {
+    try {
+        $cb();
+        echo "Unexpectedly didn't throw\n";
+    } catch (Throwable $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+expect_throws(fn() => (new ReflectionClass(Teds\LowMemoryVector::class))->newInstanceWithoutConstructor());
+$it = new Teds\LowMemoryVector([new stdClass()]);
+var_dump($it->offsetGet(0));
+var_dump($it->get(0));
+expect_throws(fn() => $it->offsetSet(1,'x'));
+expect_throws(fn() => $it->offsetUnset(0));
+var_dump($it->offsetGet('0'));
+echo "offsetExists checks\n";
+var_dump($it->offsetExists(1));
+var_dump($it->offsetExists('1'));
+var_dump($it->offsetExists(PHP_INT_MAX));
+var_dump($it->offsetExists(PHP_INT_MIN));
+expect_throws(fn() => $it->get(1));
+expect_throws(fn() => $it->get(-1));
+echo "Invalid offsetGet calls\n";
+expect_throws(fn() => $it->offsetGet(PHP_INT_MAX));
+expect_throws(fn() => $it->offsetGet(PHP_INT_MIN));
+expect_throws(fn() => $it->offsetGet(1));
+expect_throws(fn() => $it->get(PHP_INT_MAX));
+expect_throws(fn() => $it->get(PHP_INT_MIN));
+expect_throws(fn() => $it->get(1));
+expect_throws(fn() => $it->get(-1));
+expect_throws(fn() => $it->offsetGet(1));
+expect_throws(fn() => $it->offsetGet('1'));
+expect_throws(fn() => $it->offsetGet('invalid'));
+expect_throws(fn() => $it->get('invalid'));
+expect_throws(fn() => $it[['invalid']]);
+expect_throws(fn() => $it->offsetUnset(PHP_INT_MAX));
+expect_throws(fn() => $it->offsetSet(PHP_INT_MAX,'x'));
+expect_throws(function () use ($it) { unset($it[0]); });
+var_dump($it->getIterator());
+?>
+--EXPECT--
+Caught ReflectionException: Class Teds\LowMemoryVector is an internal class marked as final that cannot be instantiated without invoking its constructor
+object(stdClass)#1 (0) {
+}
+object(stdClass)#1 (0) {
+}
+Caught OutOfBoundsException: Index out of range
+Caught RuntimeException: Teds\LowMemoryVector does not support offsetUnset - elements must be set to null or removed by resizing
+object(stdClass)#1 (0) {
+}
+offsetExists checks
+bool(false)
+bool(false)
+bool(false)
+bool(false)
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Invalid offsetGet calls
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught TypeError: Illegal offset type string
+Caught TypeError: Teds\LowMemoryVector::get(): Argument #1 ($offset) must be of type int, string given
+Caught TypeError: Illegal offset type array
+Caught RuntimeException: Teds\LowMemoryVector does not support offsetUnset - elements must be set to null or removed by resizing
+Caught OutOfBoundsException: Index out of range
+Caught RuntimeException: Teds\LowMemoryVector does not support offsetUnset - elements must be set to null or removed by resizing
+object(InternalIterator)#2 (0) {
+}

--- a/tests/LowMemoryVector/push_pop.phpt
+++ b/tests/LowMemoryVector/push_pop.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Teds\LowMemoryVector push/pop
+--FILE--
+<?php
+
+function expect_throws(Closure $cb): void {
+    try {
+        $cb();
+        echo "Unexpectedly didn't throw\n";
+    } catch (Throwable $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+echo "Test empty vector\n";
+$it = new Teds\LowMemoryVector([]);
+printf("count=%d capacity=%d\n", $it->count(), $it->capacity());
+expect_throws(fn() => $it->pop());
+expect_throws(fn() => $it->pop());
+$it->push(strtoupper('test'));
+$it->push(['literal']);
+$it->push(new stdClass());
+$it[] = strtoupper('test2');
+$it[] = null;
+echo json_encode($it), "\n";
+printf("count=%d capacity=%d\n", count($it), $it->capacity());
+var_dump($it->pop());
+var_dump($it->pop());
+var_dump($it->pop());
+var_dump($it->pop());
+echo "After popping 4 elements: ", json_encode($it->toArray()), "\n";
+var_dump($it->pop());
+echo json_encode($it), "\n";
+printf("count=%d capacity=%d\n", count($it), $it->capacity());
+echo "After pushing variadic args\n";
+$it->push(strtoupper('test'), 'other', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+echo json_encode($it), "\n";
+printf("count=%d capacity=%d\n", count($it), $it->capacity());
+$it->push('a', 'b');
+echo json_encode($it), "\n";
+
+?>
+--EXPECT--
+Test empty vector
+count=0 capacity=0
+Caught UnderflowException: Cannot pop from empty Teds\LowMemoryVector
+Caught UnderflowException: Cannot pop from empty Teds\LowMemoryVector
+["TEST",["literal"],{},"TEST2",null]
+count=5 capacity=8
+NULL
+string(5) "TEST2"
+object(stdClass)#2 (0) {
+}
+array(1) {
+  [0]=>
+  string(7) "literal"
+}
+After popping 4 elements: ["TEST"]
+string(4) "TEST"
+[]
+count=0 capacity=4
+After pushing variadic args
+["TEST","other",1,2,3,4,5,6,7,8,9,10]
+count=12 capacity=16
+["TEST","other",1,2,3,4,5,6,7,8,9,10,"a","b"]

--- a/tests/LowMemoryVector/reinit_forbidden.phpt
+++ b/tests/LowMemoryVector/reinit_forbidden.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Teds\LowMemoryVector cannot be re-initialized
+--FILE--
+<?php
+
+$it = new Teds\LowMemoryVector([]);
+
+try {
+    $it->__construct(['first']);
+    echo "Unexpectedly called constructor\n";
+} catch (Throwable $t) {
+    printf("Caught %s: %s\n", $t::class, $t->getMessage());
+}
+var_dump($it);
+try {
+    $it->__unserialize([new ArrayObject(), new stdClass()]);
+    echo "Unexpectedly called __unserialize\n";
+} catch (Throwable $t) {
+    printf("Caught %s: %s\n", $t::class, $t->getMessage());
+}
+var_dump($it);
+?>
+--EXPECT--
+Caught RuntimeException: Called Teds\LowMemoryVector::__construct twice
+object(Teds\LowMemoryVector)#1 (0) {
+}
+Caught RuntimeException: Already unserialized
+object(Teds\LowMemoryVector)#1 (0) {
+}

--- a/tests/LowMemoryVector/serialization.phpt
+++ b/tests/LowMemoryVector/serialization.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Teds\LowMemoryVector can be serialized and unserialized
+--FILE--
+<?php
+
+$it = new Teds\LowMemoryVector([new stdClass()]);
+try {
+    $it->dynamicProp = 123;
+} catch (Throwable $t) {
+    printf("Caught %s: %s\n", $t::class, $t->getMessage());
+}
+/*
+$ser = serialize($it);
+echo $ser, "\n";
+foreach (unserialize($ser) as $key => $value) {
+    echo "Entry:\n";
+    var_dump($key, $value);
+}
+var_dump($ser === serialize($it));
+echo "Done\n";
+$x = 123;
+$it = new Teds\LowMemoryVector([]);
+var_dump($it->__serialize());
+ */
+?>
+--EXPECT--
+Caught Error: Cannot create dynamic property Teds\LowMemoryVector::$dynamicProp

--- a/tests/LowMemoryVector/setValueAt.phpt
+++ b/tests/LowMemoryVector/setValueAt.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Teds\LowMemoryVector offsetSet/set
+--FILE--
+<?php
+
+function expect_throws(Closure $cb): void {
+    try {
+        $cb();
+        echo "Unexpectedly didn't throw\n";
+    } catch (Throwable $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+}
+
+echo "Test empty vector\n";
+$it = new Teds\LowMemoryVector([]);
+expect_throws(fn() => $it->offsetSet(0, strtoupper('value')));
+expect_throws(fn() => $it->set(0, strtoupper('value')));
+
+echo "Test short vector\n";
+$str = 'Test short vector';
+$it = new Teds\LowMemoryVector(explode(' ', $str));
+$it->set(0, 'new');
+$it->offsetSet(2, strtoupper('test'));
+echo json_encode($it), "\n";
+expect_throws(fn() => $it->set(-1, strtoupper('value')));
+expect_throws(fn() => $it->set(3, 'end'));
+expect_throws(fn() => $it->set(PHP_INT_MAX, 'end'));
+
+?>
+--EXPECT--
+Test empty vector
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Test short vector
+["new","short","TEST"]
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range
+Caught OutOfBoundsException: Index out of range

--- a/tests/LowMemoryVector/set_state.phpt
+++ b/tests/LowMemoryVector/set_state.phpt
@@ -1,0 +1,83 @@
+--TEST--
+Teds\LowMemoryVector::__set_state
+--FILE--
+<?php
+
+function dump_repr($obj) {
+    echo str_replace(" \n", "\n", var_export($obj, true)), "\n";
+}
+dump_repr(Teds\LowMemoryVector::__set_state([]));
+Teds\LowMemoryVector::__set_state(['first' => 'x']);
+$it = Teds\LowMemoryVector::__set_state([strtoupper('a literal'), ['first', 'x'], [(object)['key' => 'value'], null]]);
+foreach ($it as $key => $value) {
+    printf("key=%s value=%s\n", json_encode($key), json_encode($value));
+}
+dump_repr($it);
+var_dump($it);
+var_dump((array)$it);
+
+?>
+--EXPECT--
+Teds\LowMemoryVector::__set_state(array(
+))
+key=0 value="A LITERAL"
+key=1 value=["first","x"]
+key=2 value=[{"key":"value"},null]
+Teds\LowMemoryVector::__set_state(array(
+   0 => 'A LITERAL',
+   1 =>
+  array (
+    0 => 'first',
+    1 => 'x',
+  ),
+   2 =>
+  array (
+    0 =>
+    (object) array(
+       'key' => 'value',
+    ),
+    1 => NULL,
+  ),
+))
+object(Teds\LowMemoryVector)#2 (3) {
+  [0]=>
+  string(9) "A LITERAL"
+  [1]=>
+  array(2) {
+    [0]=>
+    string(5) "first"
+    [1]=>
+    string(1) "x"
+  }
+  [2]=>
+  array(2) {
+    [0]=>
+    object(stdClass)#1 (1) {
+      ["key"]=>
+      string(5) "value"
+    }
+    [1]=>
+    NULL
+  }
+}
+array(3) {
+  [0]=>
+  string(9) "A LITERAL"
+  [1]=>
+  array(2) {
+    [0]=>
+    string(5) "first"
+    [1]=>
+    string(1) "x"
+  }
+  [2]=>
+  array(2) {
+    [0]=>
+    object(stdClass)#1 (1) {
+      ["key"]=>
+      string(5) "value"
+    }
+    [1]=>
+    NULL
+  }
+}

--- a/tests/LowMemoryVector/toArray.phpt
+++ b/tests/LowMemoryVector/toArray.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Teds\LowMemoryVector toArray()
+--FILE--
+<?php
+
+$it = new Teds\LowMemoryVector([new stdClass()]);
+var_dump($it->toArray());
+var_dump($it->toArray());
+$it = new Teds\LowMemoryVector([]);
+var_dump($it->toArray());
+var_dump($it->toArray());
+var_dump(Teds\LowMemoryVector::__set_state([])->toArray());
+var_dump(Teds\LowMemoryVector::__set_state([(object)[]])->toArray());
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  object(stdClass)#2 (0) {
+  }
+}
+array(1) {
+  [0]=>
+  object(stdClass)#2 (0) {
+  }
+}
+array(0) {
+}
+array(0) {
+}
+array(0) {
+}
+array(1) {
+  [0]=>
+  object(stdClass)#1 (0) {
+  }
+}

--- a/tests/LowMemoryVector/traversable.phpt
+++ b/tests/LowMemoryVector/traversable.phpt
@@ -1,0 +1,101 @@
+--TEST--
+Teds\LowMemoryVector constructed from Traversable
+--FILE--
+<?php
+
+function yields_values() {
+    for ($i = 0; $i < 10; $i++) {
+        yield "r$i" => "s$i";
+    }
+    $o = (object)['key' => 'value'];
+    yield $o => $o;
+    yield 0 => 1;
+    yield 0 => 2;
+    echo "Done evaluating the generator\n";
+}
+
+// Teds\LowMemoryVector eagerly evaluates the passed in Traversable
+$it = new Teds\LowMemoryVector(yields_values());
+foreach ($it as $key => $value) {
+    printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
+}
+echo "Rewind and iterate again starting from r0\n";
+foreach ($it as $key => $value) {
+    printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
+}
+unset($it);
+
+$emptyIt = new Teds\LowMemoryVector(new ArrayObject());
+var_dump($emptyIt);
+foreach ($emptyIt as $key => $value) {
+    echo "Unreachable\n";
+}
+foreach ($emptyIt as $key => $value) {
+    echo "Unreachable\n";
+}
+echo "Done\n";
+unset($emptyIt);
+
+?>
+--EXPECT--
+Done evaluating the generator
+Key: 0
+Value: 's0'
+Key: 1
+Value: 's1'
+Key: 2
+Value: 's2'
+Key: 3
+Value: 's3'
+Key: 4
+Value: 's4'
+Key: 5
+Value: 's5'
+Key: 6
+Value: 's6'
+Key: 7
+Value: 's7'
+Key: 8
+Value: 's8'
+Key: 9
+Value: 's9'
+Key: 10
+Value: (object) array(
+   'key' => 'value',
+)
+Key: 11
+Value: 1
+Key: 12
+Value: 2
+Rewind and iterate again starting from r0
+Key: 0
+Value: 's0'
+Key: 1
+Value: 's1'
+Key: 2
+Value: 's2'
+Key: 3
+Value: 's3'
+Key: 4
+Value: 's4'
+Key: 5
+Value: 's5'
+Key: 6
+Value: 's6'
+Key: 7
+Value: 's7'
+Key: 8
+Value: 's8'
+Key: 9
+Value: 's9'
+Key: 10
+Value: (object) array(
+   'key' => 'value',
+)
+Key: 11
+Value: 1
+Key: 12
+Value: 2
+object(Teds\LowMemoryVector)#1 (0) {
+}
+Done

--- a/tests/LowMemoryVector/unserialize.phpt
+++ b/tests/LowMemoryVector/unserialize.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Teds\LowMemoryVector unserialize error handling
+--FILE--
+<?php
+
+call_user_func(function () {
+    $ser = 'O:20:"Teds\LowMemoryVector":2:{i:0;s:5:"first";s:5:"unexp";s:6:"second";}';
+    try {
+        var_dump(unserialize($ser));
+    } catch (Throwable $e) {
+        printf("Caught %s: %s\n", $e::class, $e->getMessage());
+    }
+});
+?>
+--EXPECT--
+Caught RuntimeException: LowMemoryVector __unserialize not yet implemented


### PR DESCRIPTION
For https://github.com/TysonAndre/pecl-teds/issues/105

Instead of using 16 bytes to represent values (php-src `zval`), use
- 1 byte for bool/null
- 1, 4, or 8 bytes for signed integers
- 16 bytes for unsupported combinations
- TODO: floats
- TODO: benchmark memory, gc performance (should be nothing for int only, bool/null only)