### PR TITLE
Add Values, Collection, ListInterface interfaces.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -110,5 +110,5 @@ if test "$PHP_TEDS" != "no"; then
   dnl In case of no dependencies
   AC_DEFINE(HAVE_TEDS, 1, [ Have teds support ])
 
-  PHP_NEW_EXTENSION(teds, teds.c teds_immutablesequence.c teds_immutablekeyvaluesequence.c teds_keyvaluevector.c teds_vector.c teds_deque.c teds_sortedstrictmap.c teds_sortedstrictset.c teds_stableheap.c teds_strictmap.c teds_strictset.c teds_stablesortedlistset.c teds_stablesortedlistmap.c teds_lowmemoryvector.c teds_intvector.c, $ext_shared)
+  PHP_NEW_EXTENSION(teds, teds.c teds_immutablesequence.c teds_immutablekeyvaluesequence.c teds_keyvaluevector.c teds_vector.c teds_deque.c teds_sortedstrictmap.c teds_sortedstrictset.c teds_stableheap.c teds_strictmap.c teds_strictset.c teds_stablesortedlistset.c teds_stablesortedlistmap.c teds_lowmemoryvector.c teds_intvector.c teds_interfaces.c, $ext_shared)
 fi

--- a/config.w32
+++ b/config.w32
@@ -1,7 +1,9 @@
+// vim:ft=javascript
+
 ARG_ENABLE('teds', 'teds support', 'no');
 
 if (PHP_TEDS != 'no') {
 	AC_DEFINE('HAVE_TEDS', 1, 'teds support enabled');
 
-	EXTENSION('teds', 'teds.c teds_immutablekeyvaluesequence.c teds_immutablesequence.c teds_keyvaluevector.c teds_vector.c teds_deque.c teds_sortedstrictmap.c teds_sortedstrictset.c teds_stableheap.c teds_strictmap.c teds_strictset.c teds_stablesortedlistset.c teds_stablesortedlistmap.c teds_lowmemoryvector.c teds_intvector.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	EXTENSION('teds', 'teds.c teds_immutablekeyvaluesequence.c teds_immutablesequence.c teds_keyvaluevector.c teds_vector.c teds_deque.c teds_sortedstrictmap.c teds_sortedstrictset.c teds_stableheap.c teds_strictmap.c teds_strictset.c teds_stablesortedlistset.c teds_stablesortedlistmap.c teds_lowmemoryvector.c teds_intvector.c teds_interfaces.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 }

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,8 @@
  <date>2022-02-09</date>
  <time>16:00:00</time>
  <version>
-  <release>0.11.0</release>
-  <api>0.11.0</api>
+  <release>0.12.0dev</release>
+  <api>0.12.0dev</api>
  </version>
  <stability>
   <release>stable</release>
@@ -49,6 +49,10 @@
    <file name="teds_immutablesequence.c" role="src" />
    <file name="teds_immutablesequence.h" role="src" />
    <file name="teds_immutablesequence.stub.php" role="src" />
+   <file name="teds_interfaces_arginfo.h" role="src" />
+   <file name="teds_interfaces.c" role="src" />
+   <file name="teds_interfaces.h" role="src" />
+   <file name="teds_interfaces.stub.php" role="src" />
    <file name="teds_intvector_arginfo.h" role="src" />
    <file name="teds_intvector.c" role="src" />
    <file name="teds_intvector.h" role="src" />
@@ -257,6 +261,7 @@
     <file name="StableHeap/StableHeap.phpt" role="test" />
     <file name="StableHeap/extensible.phpt" role="test" />
     <file name="StableHeap/reflection.phpt" role="test" />
+    <file name="StableHeap/serialization.phpt" role="test" />
     <file name="StableSortedListMap/ImmutableKeyValueSequence.phpt" role="test" />
     <file name="StableSortedListMap/SortedStrictMap.phpt" role="test" />
     <file name="StableSortedListMap/aggregate.phpt" role="test" />
@@ -389,6 +394,27 @@
  <providesextension>teds</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2022-02-09</date>
+   <time>16:00:00</time>
+   <version>
+    <release>0.11.0</release>
+    <api>0.11.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
+   <notes>
+* Fix serialization/unserialization in StableMinHeap/StableMaxHeap.
+* Add interfaces for Values (e.g. Heap/Set), Teds\Collection(e.g. StrictMap, StableSortedMap), ListInterface(Vector, Deque, etc.) (the keyword list is reserved)
+* Implement ->values()
+* Make offsetExists consistently return false when the value of the given key is null across all data structures.
+* Add Teds\Collection->containsKey to return true if a key exists without coercing types, and returning true regardless of whether the corresponding key is null.
+* Change signature of IntVector::set() and ::push() to match ListInterface
+   </notes>
+  </release>
   <release>
    <date>2022-02-06</date>
    <time>16:00:00</time>

--- a/php_teds.h
+++ b/php_teds.h
@@ -23,7 +23,7 @@ extern zend_module_entry teds_module_entry;
 
 PHP_MINIT_FUNCTION(teds);
 
-# define PHP_TEDS_VERSION "0.11.0"
+# define PHP_TEDS_VERSION "0.12.0dev"
 
 # if defined(ZTS) && defined(COMPILE_DL_TEDS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/teds.c
+++ b/teds.c
@@ -35,6 +35,7 @@
 #include "teds_immutablekeyvaluesequence.h"
 #include "teds_immutablesequence.h"
 #include "teds_intvector.h"
+#include "teds_interfaces.h"
 #include "teds_keyvaluevector.h"
 #include "teds_sortedstrictmap.h"
 #include "teds_sortedstrictset.h"
@@ -1070,6 +1071,8 @@ PHP_FUNCTION(strict_hash)
 /* {{{ PHP_MINIT_FUNCTION */
 PHP_MINIT_FUNCTION(teds)
 {
+	teds_register_interfaces();
+
 	PHP_MINIT(teds_deque)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(teds_immutablekeyvaluesequence)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(teds_immutablesequence)(INIT_FUNC_ARGS_PASSTHRU);

--- a/teds_deque.stub.php
+++ b/teds_deque.stub.php
@@ -19,7 +19,7 @@ namespace Teds;
  * Naming is based on https://www.php.net/spldoublylinkedlist
  * and on array_push/pop/unshift/shift.
  */
-final class Deque implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+final class Deque implements \IteratorAggregate, ListInterface, \JsonSerializable
 {
     /** Construct the Deque from the values of the Traversable/array, ignoring keys */
     public function __construct(iterable $iterator = []) {}
@@ -72,6 +72,11 @@ final class Deque implements \IteratorAggregate, \Countable, \JsonSerializable, 
 
     /** Returns a list of the elements from front to back. */
     public function toArray(): array {}
+    /**
+     * @override
+     * @implementation-alias Teds\Deque::toArray
+     */
+    public function values(): array {}
     /* Get and set are strictly typed, unlike offsetGet/offsetSet. */
     /**
      * Returns the value at offset $offset (relative to the start of the Deque)
@@ -90,9 +95,14 @@ final class Deque implements \IteratorAggregate, \Countable, \JsonSerializable, 
      */
     public function offsetGet(mixed $offset): mixed {}
     /**
-     * Returns true if `0 <= (int)$offset && (int)$offset < $this->count().
+     * Returns true if `0 <= (int)$offset && (int)$offset < $this->count()
+     * AND the value of offsetGet is non-null.
      */
     public function offsetExists(mixed $offset): bool {}
+    /**
+     * Returns true if `is_int($offset) && 0 <= $offset && $offset < $this->count().
+     */
+    public function containsKey(mixed $offset): bool {}
     /**
      * Sets the value at offset $offset (relative to the start of the Deque) to $value
      * @throws \OutOfBoundsException if the value of (int)$offset is not within the bounds of this vector

--- a/teds_deque_arginfo.h
+++ b/teds_deque_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: fbf18feb5867f2852f7fd8cc6a540fbe51f992af */
+ * Stub hash: 714be477424e76004ddd407e3a28d4b83c529233 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Deque___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -45,6 +45,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_Deque_toArray arginfo_class_Teds_Deque___serialize
 
+#define arginfo_class_Teds_Deque_values arginfo_class_Teds_Deque___serialize
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -61,6 +63,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_offsetExists, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_Deque_containsKey arginfo_class_Teds_Deque_offsetExists
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Deque_offsetSet, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
@@ -102,6 +106,7 @@ ZEND_METHOD(Teds_Deque, get);
 ZEND_METHOD(Teds_Deque, set);
 ZEND_METHOD(Teds_Deque, offsetGet);
 ZEND_METHOD(Teds_Deque, offsetExists);
+ZEND_METHOD(Teds_Deque, containsKey);
 ZEND_METHOD(Teds_Deque, offsetSet);
 ZEND_METHOD(Teds_Deque, offsetUnset);
 ZEND_METHOD(Teds_Deque, indexOf);
@@ -125,10 +130,12 @@ static const zend_function_entry class_Teds_Deque_methods[] = {
 	ZEND_ME(Teds_Deque, bottom, arginfo_class_Teds_Deque_bottom, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, top, arginfo_class_Teds_Deque_top, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, toArray, arginfo_class_Teds_Deque_toArray, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_Deque, values, toArray, arginfo_class_Teds_Deque_values, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, get, arginfo_class_Teds_Deque_get, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, set, arginfo_class_Teds_Deque_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, offsetGet, arginfo_class_Teds_Deque_offsetGet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, offsetExists, arginfo_class_Teds_Deque_offsetExists, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_Deque, containsKey, arginfo_class_Teds_Deque_containsKey, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, offsetSet, arginfo_class_Teds_Deque_offsetSet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, offsetUnset, arginfo_class_Teds_Deque_offsetUnset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Deque, indexOf, arginfo_class_Teds_Deque_indexOf, ZEND_ACC_PUBLIC)
@@ -138,14 +145,14 @@ static const zend_function_entry class_Teds_Deque_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_Deque(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+static zend_class_entry *register_class_Teds_Deque(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_ListInterface, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "Deque", class_Teds_Deque_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_ListInterface, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_immutablekeyvaluesequence.c
+++ b/teds_immutablekeyvaluesequence.c
@@ -20,6 +20,7 @@
 #include "php_teds.h"
 #include "teds.h"
 #include "teds_util.h"
+#include "teds_interfaces.h"
 #include "teds_immutablekeyvaluesequence_arginfo.h"
 #include "teds_immutablekeyvaluesequence.h"
 // #include "ext/spl/spl_functions.h"
@@ -959,7 +960,7 @@ PHP_METHOD(Teds_ImmutableKeyValueSequence, toPairs)
 PHP_MINIT_FUNCTION(teds_immutablekeyvaluesequence)
 {
 	TEDS_MINIT_IGNORE_UNUSED();
-	teds_ce_ImmutableKeyValueSequence = register_class_Teds_ImmutableKeyValueSequence(zend_ce_aggregate, zend_ce_countable, php_json_serializable_ce);
+	teds_ce_ImmutableKeyValueSequence = register_class_Teds_ImmutableKeyValueSequence(zend_ce_aggregate, teds_ce_Values, php_json_serializable_ce);
 	teds_ce_ImmutableKeyValueSequence->create_object = teds_immutablekeyvaluesequence_new;
 
 	memcpy(&teds_handler_ImmutableKeyValueSequence, &std_object_handlers, sizeof(zend_object_handlers));

--- a/teds_immutablekeyvaluesequence.stub.php
+++ b/teds_immutablekeyvaluesequence.stub.php
@@ -8,7 +8,7 @@ namespace Teds;
 /**
  * An immutable sequence of keys and values, where keys are repeatable and can be any type.
  */
-final class ImmutableKeyValueSequence implements \IteratorAggregate, \Countable, \JsonSerializable
+final class ImmutableKeyValueSequence implements \IteratorAggregate, Values, \JsonSerializable
 {
     public function __construct(iterable $iterator) {}
     public function getIterator(): \InternalIterator {}

--- a/teds_immutablekeyvaluesequence_arginfo.h
+++ b/teds_immutablekeyvaluesequence_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8f5543c5ef0eb2de2d99129164aae08911c3c45e */
+ * Stub hash: cf6bad4ba4e53ad24783c44d758801e687830c43 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_ImmutableKeyValueSequence___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, iterator, IS_ITERABLE, 0)
@@ -101,14 +101,14 @@ static const zend_function_entry class_Teds_ImmutableKeyValueSequence_methods[] 
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_ImmutableKeyValueSequence(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable)
+static zend_class_entry *register_class_Teds_ImmutableKeyValueSequence(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Values, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "ImmutableKeyValueSequence", class_Teds_ImmutableKeyValueSequence_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Values, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_immutablesequence.stub.php
+++ b/teds_immutablesequence.stub.php
@@ -12,7 +12,7 @@ namespace Teds;
  * This is backed by a memory-efficient representation
  * (raw array of values).
  */
-final class ImmutableSequence implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+final class ImmutableSequence implements \IteratorAggregate, Collection, \JsonSerializable
 {
     public function __construct(iterable $iterator) {}
     public function getIterator(): \InternalIterator {}
@@ -28,11 +28,17 @@ final class ImmutableSequence implements \IteratorAggregate, \Countable, \JsonSe
     public static function __set_state(array $array): ImmutableSequence {}
 
     public function toArray(): array {}
+    /**
+     * @override
+     * @implementation-alias Teds\ImmutableSequence::toArray
+     */
+    public function values(): array {}
     // Strictly typed, unlike offsetGet
     public function get(int $offset): mixed {}
     // Must be mixed for compatibility with ArrayAccess
     public function offsetGet(mixed $offset): mixed {}
     public function offsetExists(mixed $offset): bool {}
+    public function containsKey(mixed $offset): bool {}
     // Throws
     public function offsetSet(mixed $offset, mixed $value): void {}
     // Throws

--- a/teds_immutablesequence_arginfo.h
+++ b/teds_immutablesequence_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6c721768a79fd388fe9b09f386e76f9f8d3a3684 */
+ * Stub hash: 9c890e617949351b288c30e833b8c208c3c43fbe */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_ImmutableSequence___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, iterator, IS_ITERABLE, 0)
@@ -27,6 +27,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_ImmutableSequence_toArray arginfo_class_Teds_ImmutableSequence___serialize
 
+#define arginfo_class_Teds_ImmutableSequence_values arginfo_class_Teds_ImmutableSequence___serialize
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableSequence_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -38,6 +40,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableSequence_offsetExists, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_ImmutableSequence_containsKey arginfo_class_Teds_ImmutableSequence_offsetExists
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableSequence_offsetSet, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
@@ -77,6 +81,7 @@ ZEND_METHOD(Teds_ImmutableSequence, __set_state);
 ZEND_METHOD(Teds_ImmutableSequence, get);
 ZEND_METHOD(Teds_ImmutableSequence, offsetGet);
 ZEND_METHOD(Teds_ImmutableSequence, offsetExists);
+ZEND_METHOD(Teds_ImmutableSequence, containsKey);
 ZEND_METHOD(Teds_ImmutableSequence, offsetSet);
 ZEND_METHOD(Teds_ImmutableSequence, offsetUnset);
 ZEND_METHOD(Teds_ImmutableSequence, indexOf);
@@ -94,9 +99,11 @@ static const zend_function_entry class_Teds_ImmutableSequence_methods[] = {
 	ZEND_ME(Teds_ImmutableSequence, __unserialize, arginfo_class_Teds_ImmutableSequence___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, __set_state, arginfo_class_Teds_ImmutableSequence___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Teds_ImmutableSequence, toArray, arginfo_class_Teds_ImmutableSequence_toArray, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_ImmutableSequence, values, toArray, arginfo_class_Teds_ImmutableSequence_values, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, get, arginfo_class_Teds_ImmutableSequence_get, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, offsetGet, arginfo_class_Teds_ImmutableSequence_offsetGet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, offsetExists, arginfo_class_Teds_ImmutableSequence_offsetExists, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_ImmutableSequence, containsKey, arginfo_class_Teds_ImmutableSequence_containsKey, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, offsetSet, arginfo_class_Teds_ImmutableSequence_offsetSet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, offsetUnset, arginfo_class_Teds_ImmutableSequence_offsetUnset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_ImmutableSequence, indexOf, arginfo_class_Teds_ImmutableSequence_indexOf, ZEND_ACC_PUBLIC)
@@ -107,14 +114,14 @@ static const zend_function_entry class_Teds_ImmutableSequence_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_ImmutableSequence(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+static zend_class_entry *register_class_Teds_ImmutableSequence(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Collection, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "ImmutableSequence", class_Teds_ImmutableSequence_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Collection, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_interfaces.c
+++ b/teds_interfaces.c
@@ -1,0 +1,17 @@
+#include "Zend/zend_interfaces.h"
+#include "php.h"
+#include "teds_interfaces.h"
+#include "teds_interfaces_arginfo.h"
+#include "ext/json/php_json.h"
+
+zend_class_entry *teds_ce_Values;
+zend_class_entry *teds_ce_Collection;
+zend_class_entry *teds_ce_ListInterface;
+
+
+void teds_register_interfaces(void)
+{
+	teds_ce_Values = register_class_Teds_Values(zend_ce_traversable, zend_ce_countable);
+	teds_ce_Collection = register_class_Teds_Collection(teds_ce_Values, zend_ce_arrayaccess);
+	teds_ce_ListInterface = register_class_Teds_ListInterface(teds_ce_Collection);
+}

--- a/teds_interfaces.h
+++ b/teds_interfaces.h
@@ -1,0 +1,21 @@
+/*
+  +----------------------------------------------------------------------+
+  | teds extension for PHP                                               |
+  | See COPYING file for further copyright information                   |
+  +----------------------------------------------------------------------+
+  | Author: Tyson Andre <tandre@php.net>                                 |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef TEDS_INTERFACES_H
+#define TEDS_INTERFACES_H
+
+#include "Zend/zend_types.h"
+
+extern zend_class_entry *teds_ce_Values;
+extern zend_class_entry *teds_ce_Collection;
+extern zend_class_entry *teds_ce_ListInterface;
+
+void teds_register_interfaces(void);
+
+#endif	/* TEDS_INTERFACES_H */

--- a/teds_interfaces.stub.php
+++ b/teds_interfaces.stub.php
@@ -1,0 +1,61 @@
+<?php
+
+/** @generate-class-entries */
+
+namespace Teds;
+
+/**
+ * Values is a common interface for an object with values that can be iterated over and counted,
+ * but not addressed with ArrayAccess (e.g. Sets, Heaps, objects that yield values in an order in their iterators, etc.)
+ */
+interface Values extends \Traversable, \Countable {
+    /** @psalm-return list<values> */
+    public function values(): array {}
+
+    /** Returns true if count() would be 0 */
+    public function isEmpty(): bool {}
+}
+
+/**
+ * A sequence represents a list of values that can be iterated over and counted,
+ * but not addressed with ArrayAccess (e.g. Sets, Heaps, objects that yield values in an order in their iterators, etc.)
+ *
+ * Note: JsonSerializable was not included here because
+ * 1. Causes issues or inefficiencies with some ways of implementing data structures internally.
+ * 2. Forces the result to be represented as []
+ * 3. Forces polyfills to implement JsonSerializable as well, even when it would be less efficient
+ */
+interface Collection extends Values, \ArrayAccess {
+    /**
+     * Returns a list or associative array,
+     * typically attempting to cast keys to array key types (int/string) to insert elements of the collection into the array, or throwing.
+     *
+     * When this is impossible for the class in general,
+     * this returns an array with representations of key/value entries of the Collection.
+     */
+    // public function toArray(): array {}
+
+    // clear will throw UnsupportedException on immutables.
+    /**
+     * Returns true if there exists a key === $key in this Collection.
+     */
+    public function containsKey(mixed $value): bool {}
+}
+
+/**
+ * but not addressed with ArrayAccess (e.g. Sets, Heaps, objects that yield values in an order in their iterators, etc.)
+ *
+ * Note: JsonSerializable was not included here because
+ * 1. Causes issues or inefficiencies with some ways of implementing data structures internally.
+ * 2. Forces the result to be represented as []
+ * 3. Forces polyfills to implement JsonSerializable as well, even when it would be less efficient
+ *
+ * NOTE: List is a reserved keyword in php and cannot be used as an identifier, e.g. `list($x) = [1]`.
+ */
+interface ListInterface extends Collection {
+    public function get(int $key): mixed {}
+    public function set(int $offset, mixed $value): void {}
+
+    public function push(mixed ...$values): void {}
+    public function pop(): mixed {}
+}

--- a/teds_interfaces_arginfo.h
+++ b/teds_interfaces_arginfo.h
@@ -1,0 +1,85 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: a8ef4e1cf7a8734cd0a20620cdd911aa43808170 */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Values_values, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Values_isEmpty, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Collection_containsKey, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ListInterface_get, 0, 1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ListInterface_set, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ListInterface_push, 0, 0, IS_VOID, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, values, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ListInterface_pop, 0, 0, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+
+
+
+static const zend_function_entry class_Teds_Values_methods[] = {
+	ZEND_ABSTRACT_ME_WITH_FLAGS(Teds_Values, values, arginfo_class_Teds_Values_values, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(Teds_Values, isEmpty, arginfo_class_Teds_Values_isEmpty, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Teds_Collection_methods[] = {
+	ZEND_ABSTRACT_ME_WITH_FLAGS(Teds_Collection, containsKey, arginfo_class_Teds_Collection_containsKey, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_FE_END
+};
+
+
+static const zend_function_entry class_Teds_ListInterface_methods[] = {
+	ZEND_ABSTRACT_ME_WITH_FLAGS(Teds_ListInterface, get, arginfo_class_Teds_ListInterface_get, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(Teds_ListInterface, set, arginfo_class_Teds_ListInterface_set, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(Teds_ListInterface, push, arginfo_class_Teds_ListInterface_push, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_ABSTRACT_ME_WITH_FLAGS(Teds_ListInterface, pop, arginfo_class_Teds_ListInterface_pop, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_FE_END
+};
+
+static zend_class_entry *register_class_Teds_Values(zend_class_entry *class_entry_Traversable, zend_class_entry *class_entry_Countable)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Teds", "Values", class_Teds_Values_methods);
+	class_entry = zend_register_internal_interface(&ce);
+	zend_class_implements(class_entry, 2, class_entry_Traversable, class_entry_Countable);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Teds_Collection(zend_class_entry *class_entry_Teds_Values, zend_class_entry *class_entry_ArrayAccess)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Teds", "Collection", class_Teds_Collection_methods);
+	class_entry = zend_register_internal_interface(&ce);
+	zend_class_implements(class_entry, 2, class_entry_Teds_Values, class_entry_ArrayAccess);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Teds_ListInterface(zend_class_entry *class_entry_Teds_Collection)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Teds", "ListInterface", class_Teds_ListInterface_methods);
+	class_entry = zend_register_internal_interface(&ce);
+	zend_class_implements(class_entry, 1, class_entry_Teds_Collection);
+
+	return class_entry;
+}

--- a/teds_intvector.stub.php
+++ b/teds_intvector.stub.php
@@ -21,7 +21,7 @@ namespace Teds;
  *
  * In comparison, in 64-bit builds of PHP, PHP's arrays take at least 16 bytes per value in php 8.2, and at least 32 bytes per value before php 8.1, at the time of writing.
  */
-final class IntVector implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+final class IntVector implements \IteratorAggregate, ListInterface, \JsonSerializable
 {
     /**
      * Construct a IntVector from an iterable of integers.
@@ -54,7 +54,8 @@ final class IntVector implements \IteratorAggregate, \Countable, \JsonSerializab
     /** Create this from an array */
     public static function __set_state(array $array): IntVector {}
 
-    public function push(int ...$values): void {}
+    public function push(mixed ...$values): void {}
+    public function pushInts(int ...$values): void {}
     /**
      * @throws \RuntimeException if there are no more elements
      */
@@ -62,9 +63,15 @@ final class IntVector implements \IteratorAggregate, \Countable, \JsonSerializab
 
     /** @psalm-return list<int> */
     public function toArray(): array {}
+    /** @implementation-alias Teds\IntVector::toArray */
+    public function values(): array {}
     // Strictly typed, unlike offsetGet/offsetSet
     public function get(int $offset): int {}
-    public function set(int $offset, int $value): void {}
+    /**
+     * Must be mixed $value to implement ListInterface
+     */
+    public function set(int $offset, mixed $value): void {}
+    public function setInt(int $offset, int $value): void {}
 
     /**
      * Returns the value at (int)$offset.
@@ -78,6 +85,10 @@ final class IntVector implements \IteratorAggregate, \Countable, \JsonSerializab
      * @psalm-param int $offset
      */
     public function offsetExists(mixed $offset): bool {}
+    /**
+     * Returns true if `is_int($offset) && 0 <= $offset && $offset < $this->count().
+     */
+    public function containsKey(mixed $offset): bool {}
 
     /**
      * Sets the value at offset (int)$offset to $value

--- a/teds_intvector_arginfo.h
+++ b/teds_intvector_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3db6ce95728a0da016ce76c9ae79f64f71d5c432 */
+ * Stub hash: e597407fa9d50af1bfbcd13f829e82b9b82dc1ab */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_IntVector___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -28,6 +28,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_IntVector___set_state,
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_IntVector_push, 0, 0, IS_VOID, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, values, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_IntVector_pushInts, 0, 0, IS_VOID, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, values, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
@@ -35,11 +39,18 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_IntVector_toArray arginfo_class_Teds_IntVector___serialize
 
+#define arginfo_class_Teds_IntVector_values arginfo_class_Teds_IntVector___serialize
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_IntVector_get, 0, 1, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_IntVector_set, 0, 2, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_IntVector_setInt, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -51,6 +62,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_IntVector_offsetExists, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_IntVector_containsKey arginfo_class_Teds_IntVector_offsetExists
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_IntVector_offsetSet, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
@@ -81,12 +94,15 @@ ZEND_METHOD(Teds_IntVector, __serialize);
 ZEND_METHOD(Teds_IntVector, __unserialize);
 ZEND_METHOD(Teds_IntVector, __set_state);
 ZEND_METHOD(Teds_IntVector, push);
+ZEND_METHOD(Teds_IntVector, pushInts);
 ZEND_METHOD(Teds_IntVector, pop);
 ZEND_METHOD(Teds_IntVector, toArray);
 ZEND_METHOD(Teds_IntVector, get);
 ZEND_METHOD(Teds_IntVector, set);
+ZEND_METHOD(Teds_IntVector, setInt);
 ZEND_METHOD(Teds_IntVector, offsetGet);
 ZEND_METHOD(Teds_IntVector, offsetExists);
+ZEND_METHOD(Teds_IntVector, containsKey);
 ZEND_METHOD(Teds_IntVector, offsetSet);
 ZEND_METHOD(Teds_IntVector, offsetUnset);
 ZEND_METHOD(Teds_IntVector, indexOf);
@@ -103,12 +119,16 @@ static const zend_function_entry class_Teds_IntVector_methods[] = {
 	ZEND_ME(Teds_IntVector, __unserialize, arginfo_class_Teds_IntVector___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, __set_state, arginfo_class_Teds_IntVector___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Teds_IntVector, push, arginfo_class_Teds_IntVector_push, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_IntVector, pushInts, arginfo_class_Teds_IntVector_pushInts, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, pop, arginfo_class_Teds_IntVector_pop, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, toArray, arginfo_class_Teds_IntVector_toArray, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_IntVector, values, toArray, arginfo_class_Teds_IntVector_values, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, get, arginfo_class_Teds_IntVector_get, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, set, arginfo_class_Teds_IntVector_set, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_IntVector, setInt, arginfo_class_Teds_IntVector_setInt, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, offsetGet, arginfo_class_Teds_IntVector_offsetGet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, offsetExists, arginfo_class_Teds_IntVector_offsetExists, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_IntVector, containsKey, arginfo_class_Teds_IntVector_containsKey, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, offsetSet, arginfo_class_Teds_IntVector_offsetSet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, offsetUnset, arginfo_class_Teds_IntVector_offsetUnset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_IntVector, indexOf, arginfo_class_Teds_IntVector_indexOf, ZEND_ACC_PUBLIC)
@@ -117,14 +137,14 @@ static const zend_function_entry class_Teds_IntVector_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_IntVector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+static zend_class_entry *register_class_Teds_IntVector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_ListInterface, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "IntVector", class_Teds_IntVector_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_ListInterface, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_keyvaluevector.stub.php
+++ b/teds_keyvaluevector.stub.php
@@ -8,7 +8,7 @@ namespace Teds;
 /**
  * A mutable vector of keys and values, where keys are repeatable and can be any type.
  */
-final class KeyValueVector implements \IteratorAggregate, \Countable, \JsonSerializable
+final class KeyValueVector implements \IteratorAggregate, Values, \JsonSerializable
 {
     public function __construct(iterable $iterator = []) {}
     public function getIterator(): \InternalIterator {}
@@ -30,7 +30,9 @@ final class KeyValueVector implements \IteratorAggregate, \Countable, \JsonSeria
     public function push(mixed $key, mixed $value): void {}
     public function pop(): array {}
 
+    /** @psalm-return list<mixed> */
     public function keys(): array {}
+    /** @psalm-return list<mixed> */
     public function values(): array {}
     public function keyAt(int $offset): mixed {}
     public function valueAt(int $offset): mixed {}

--- a/teds_keyvaluevector_arginfo.h
+++ b/teds_keyvaluevector_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 571e350936d3d2cbe063d6dc9cf5e94decc6342d */
+ * Stub hash: 434fc6d66ac10c251d7244b8060fd8ca3fe2164d */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_KeyValueVector___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -145,14 +145,14 @@ static const zend_function_entry class_Teds_KeyValueVector_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_KeyValueVector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable)
+static zend_class_entry *register_class_Teds_KeyValueVector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Values, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "KeyValueVector", class_Teds_KeyValueVector_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Values, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_lowmemoryvector.stub.php
+++ b/teds_lowmemoryvector.stub.php
@@ -32,7 +32,7 @@ namespace Teds;
  *
  * In comparison, in 64-bit builds of PHP, PHP's arrays take at least 16 bytes per value in php 8.2, and at least 32 bytes per value before php 8.1, at the time of writing.
  */
-final class LowMemoryVector implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+final class LowMemoryVector implements \IteratorAggregate, ListInterface, \JsonSerializable
 {
     /**
      * Construct a LowMemoryVector from an iterable.
@@ -70,7 +70,10 @@ final class LowMemoryVector implements \IteratorAggregate, \Countable, \JsonSeri
     public function push(mixed ...$values): void {}
     public function pop(): mixed {}
 
+    /** @psalm-return list<mixed> */
     public function toArray(): array {}
+    /** @implementation-alias Teds\LowMemoryVector::toArray */
+    public function values(): array {}
     // Strictly typed, unlike offsetGet/offsetSet
     public function get(int $offset): mixed {}
     public function set(int $offset, mixed $value): void {}
@@ -82,9 +85,14 @@ final class LowMemoryVector implements \IteratorAggregate, \Countable, \JsonSeri
     public function offsetGet(mixed $offset): mixed {}
 
     /**
-     * Returns true if `0 <= (int)$offset && (int)$offset < $this->count().
+     * Returns true if `0 <= (int)$offset && (int)$offset < $this->count()
+     * AND the value of offsetGet($offset) is not null.
      */
     public function offsetExists(mixed $offset): bool {}
+    /**
+     * Returns true if `is_int($offset) && 0 <= $offset && $offset < $this->count().
+     */
+    public function containsKey(mixed $offset): bool {}
 
     /**
      * Sets the value at offset (int)$offset to $value

--- a/teds_lowmemoryvector_arginfo.h
+++ b/teds_lowmemoryvector_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 1f93ee2bb9efeadcda35b594d1855accb1ea95a9 */
+ * Stub hash: 8dab1eed84ec8ff38605dfa35dc000be1fe7f59e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_LowMemoryVector___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -36,6 +36,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_LowMemoryVector_toArray arginfo_class_Teds_LowMemoryVector___serialize
 
+#define arginfo_class_Teds_LowMemoryVector_values arginfo_class_Teds_LowMemoryVector___serialize
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -52,6 +54,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_offsetExists, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_LowMemoryVector_containsKey arginfo_class_Teds_LowMemoryVector_offsetExists
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_LowMemoryVector_offsetSet, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
@@ -88,6 +92,7 @@ ZEND_METHOD(Teds_LowMemoryVector, get);
 ZEND_METHOD(Teds_LowMemoryVector, set);
 ZEND_METHOD(Teds_LowMemoryVector, offsetGet);
 ZEND_METHOD(Teds_LowMemoryVector, offsetExists);
+ZEND_METHOD(Teds_LowMemoryVector, containsKey);
 ZEND_METHOD(Teds_LowMemoryVector, offsetSet);
 ZEND_METHOD(Teds_LowMemoryVector, offsetUnset);
 ZEND_METHOD(Teds_LowMemoryVector, indexOf);
@@ -106,10 +111,12 @@ static const zend_function_entry class_Teds_LowMemoryVector_methods[] = {
 	ZEND_ME(Teds_LowMemoryVector, push, arginfo_class_Teds_LowMemoryVector_push, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, pop, arginfo_class_Teds_LowMemoryVector_pop, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, toArray, arginfo_class_Teds_LowMemoryVector_toArray, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_LowMemoryVector, values, toArray, arginfo_class_Teds_LowMemoryVector_values, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, get, arginfo_class_Teds_LowMemoryVector_get, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, set, arginfo_class_Teds_LowMemoryVector_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, offsetGet, arginfo_class_Teds_LowMemoryVector_offsetGet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, offsetExists, arginfo_class_Teds_LowMemoryVector_offsetExists, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_LowMemoryVector, containsKey, arginfo_class_Teds_LowMemoryVector_containsKey, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, offsetSet, arginfo_class_Teds_LowMemoryVector_offsetSet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, offsetUnset, arginfo_class_Teds_LowMemoryVector_offsetUnset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_LowMemoryVector, indexOf, arginfo_class_Teds_LowMemoryVector_indexOf, ZEND_ACC_PUBLIC)
@@ -118,14 +125,14 @@ static const zend_function_entry class_Teds_LowMemoryVector_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_LowMemoryVector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+static zend_class_entry *register_class_Teds_LowMemoryVector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_ListInterface, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "LowMemoryVector", class_Teds_LowMemoryVector_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_ListInterface, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_sortedstrictmap.c
+++ b/teds_sortedstrictmap.c
@@ -21,6 +21,7 @@
 #include "teds_sortedstrictmap_arginfo.h"
 #include "teds_sortedstrictmap.h"
 #include "teds_util.h"
+#include "teds_interfaces.h"
 #include "teds.h"
 // #include "ext/spl/spl_functions.h"
 #include "ext/spl/spl_engine.h"
@@ -1662,7 +1663,7 @@ PHP_METHOD(Teds_SortedStrictMap, clear)
 PHP_MINIT_FUNCTION(teds_sortedstrictmap)
 {
 	TEDS_MINIT_IGNORE_UNUSED();
-	teds_ce_SortedStrictMap = register_class_Teds_SortedStrictMap(zend_ce_aggregate, zend_ce_countable, php_json_serializable_ce, zend_ce_arrayaccess);
+	teds_ce_SortedStrictMap = register_class_Teds_SortedStrictMap(zend_ce_aggregate, teds_ce_Collection, php_json_serializable_ce);
 	teds_ce_SortedStrictMap->create_object = teds_sortedstrictmap_new;
 
 	memcpy(&teds_handler_SortedStrictMap, &std_object_handlers, sizeof(zend_object_handlers));

--- a/teds_sortedstrictmap.stub.php
+++ b/teds_sortedstrictmap.stub.php
@@ -14,7 +14,7 @@ namespace Teds;
  *
  * This is backed by a balanced red-black tree to ensure that insertions/removals/lookups take logarithmic time in the worst case.
  */
-final class SortedStrictMap implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+final class SortedStrictMap implements \IteratorAggregate, Collection, \JsonSerializable
 {
     /** Construct the SortedStrictMap from the keys and values of the Traversable/array. */
     public function __construct(iterable $iterator = []) {}
@@ -97,8 +97,10 @@ final class SortedStrictMap implements \IteratorAggregate, \Countable, \JsonSeri
     public function containsValue(mixed $value): bool {}
 
     /**
-     * Returns true if there exists a key === $key in this SortedStrictMap.
+     * Returns true if there exists a key where `stable_compare($key, $other) === 0` in this SortedStrictMap.
      * Unlike offsetExists, this returns true even if the corresponding value is null.
+     *
+     * Note that this is not exactly `===` but close: NAN !== NAN but this will return true for NAN.
      */
     public function containsKey(mixed $value): bool {}
 

--- a/teds_sortedstrictmap_arginfo.h
+++ b/teds_sortedstrictmap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 8d4403aff629f8794d9014d9172920a73aa4942d */
+ * Stub hash: 1b78708458bb6ec1a524061dbce9cae5134608dc */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_SortedStrictMap___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -147,14 +147,14 @@ static const zend_function_entry class_Teds_SortedStrictMap_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_SortedStrictMap(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+static zend_class_entry *register_class_Teds_SortedStrictMap(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Collection, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "SortedStrictMap", class_Teds_SortedStrictMap_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Collection, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_sortedstrictset.c
+++ b/teds_sortedstrictset.c
@@ -21,6 +21,7 @@
 #include "teds_sortedstrictset_arginfo.h"
 #include "teds_sortedstrictset.h"
 #include "teds_util.h"
+#include "teds_interfaces.h"
 #include "teds.h"
 // #include "ext/spl/spl_functions.h"
 #include "ext/spl/spl_engine.h"
@@ -1338,7 +1339,7 @@ PHP_METHOD(Teds_SortedStrictSet, clear)
 PHP_MINIT_FUNCTION(teds_sortedstrictset)
 {
 	TEDS_MINIT_IGNORE_UNUSED();
-	teds_ce_SortedStrictSet = register_class_Teds_SortedStrictSet(zend_ce_aggregate, zend_ce_countable, php_json_serializable_ce);
+	teds_ce_SortedStrictSet = register_class_Teds_SortedStrictSet(zend_ce_aggregate, teds_ce_Values, php_json_serializable_ce);
 	teds_ce_SortedStrictSet->create_object = teds_sortedstrictset_new;
 
 	memcpy(&teds_handler_SortedStrictSet, &std_object_handlers, sizeof(zend_object_handlers));

--- a/teds_sortedstrictset.stub.php
+++ b/teds_sortedstrictset.stub.php
@@ -14,7 +14,7 @@ namespace Teds;
  *
  * This is backed by a balanced red-black tree to ensure that insertions/removals/lookups take logarithmic time in the worst case.
  */
-final class SortedStrictSet implements \IteratorAggregate, \Countable, \JsonSerializable
+final class SortedStrictSet implements \IteratorAggregate, Values, \JsonSerializable
 {
     /** Construct the SortedStrictSet from the keys and values of the Traversable/array. */
     public function __construct(iterable $iterator = []) {}

--- a/teds_sortedstrictset_arginfo.h
+++ b/teds_sortedstrictset_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cf1869416076f877c1daea047fc394361bfd77c4 */
+ * Stub hash: 2aa3f63ed94fd4f3827bcbca8c3dc6ee3601ff20 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_SortedStrictSet___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -96,14 +96,14 @@ static const zend_function_entry class_Teds_SortedStrictSet_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_SortedStrictSet(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable)
+static zend_class_entry *register_class_Teds_SortedStrictSet(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Values, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "SortedStrictSet", class_Teds_SortedStrictSet_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Values, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_stableheap.stub.php
+++ b/teds_stableheap.stub.php
@@ -7,7 +7,7 @@ namespace Teds;
 
 /** @generate-class-entries */
 
-final class StableMinHeap implements Iterator, Countable
+final class StableMinHeap implements Iterator, Values
 {
     public function __construct(iterable $values = []) {}
 
@@ -40,9 +40,16 @@ final class StableMinHeap implements Iterator, Countable
     public function clear(): void {}
 
     public static function __set_state(array $state): StableMinHeap { }
+
+    /** @return list<mixed> */
+    public function values(): array {}
+
+    /** @implementation-alias Teds\StableMinHeap::values */
+    public function __serialize(): array {}
+    public function __unserialize(array $data): void {}
 }
 
-final class StableMaxHeap implements Iterator, Countable
+final class StableMaxHeap implements Iterator, Values
 {
     public function __construct(iterable $values = []) {}
 
@@ -77,4 +84,11 @@ final class StableMaxHeap implements Iterator, Countable
     public function clear(): void {}
 
     public static function __set_state(array $state): StableMaxHeap { }
+
+    /** @implementation-alias Teds\StableMinHeap::values */
+    public function values(): array {}
+
+    /** @implementation-alias Teds\StableMinHeap::values */
+    public function __serialize(): array {}
+    public function __unserialize(array $data): void {}
 }

--- a/teds_stableheap_arginfo.h
+++ b/teds_stableheap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a80c9a427760d6a066aadce00d57e44073d1db85 */
+ * Stub hash: 6ac8855e1a4bd7ffa81af4da39cdd349678f676f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StableMinHeap___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, values, IS_ITERABLE, 0, "[]")
@@ -37,6 +37,15 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StableMinHeap___set_st
 	ZEND_ARG_TYPE_INFO(0, state, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_StableMinHeap_values, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_StableMinHeap___serialize arginfo_class_Teds_StableMinHeap_values
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_StableMinHeap___unserialize, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_Teds_StableMaxHeap___construct arginfo_class_Teds_StableMinHeap___construct
 
 #define arginfo_class_Teds_StableMaxHeap_add arginfo_class_Teds_StableMinHeap_add
@@ -65,6 +74,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StableMaxHeap___set_st
 	ZEND_ARG_TYPE_INFO(0, state, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_class_Teds_StableMaxHeap_values arginfo_class_Teds_StableMinHeap_values
+
+#define arginfo_class_Teds_StableMaxHeap___serialize arginfo_class_Teds_StableMinHeap_values
+
+#define arginfo_class_Teds_StableMaxHeap___unserialize arginfo_class_Teds_StableMinHeap___unserialize
+
 
 ZEND_METHOD(Teds_StableMinHeap, __construct);
 ZEND_METHOD(Teds_StableMinHeap, add);
@@ -77,11 +92,14 @@ ZEND_METHOD(Teds_StableMinHeap, next);
 ZEND_METHOD(Teds_StableMinHeap, valid);
 ZEND_METHOD(Teds_StableMinHeap, clear);
 ZEND_METHOD(Teds_StableMinHeap, __set_state);
+ZEND_METHOD(Teds_StableMinHeap, values);
+ZEND_METHOD(Teds_StableMinHeap, __unserialize);
 ZEND_METHOD(Teds_StableMaxHeap, __construct);
 ZEND_METHOD(Teds_StableMaxHeap, add);
 ZEND_METHOD(Teds_StableMaxHeap, extract);
 ZEND_METHOD(Teds_StableMaxHeap, next);
 ZEND_METHOD(Teds_StableMaxHeap, __set_state);
+ZEND_METHOD(Teds_StableMaxHeap, __unserialize);
 
 
 static const zend_function_entry class_Teds_StableMinHeap_methods[] = {
@@ -98,6 +116,9 @@ static const zend_function_entry class_Teds_StableMinHeap_methods[] = {
 	ZEND_ME(Teds_StableMinHeap, valid, arginfo_class_Teds_StableMinHeap_valid, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StableMinHeap, clear, arginfo_class_Teds_StableMinHeap_clear, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StableMinHeap, __set_state, arginfo_class_Teds_StableMinHeap___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Teds_StableMinHeap, values, arginfo_class_Teds_StableMinHeap_values, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_StableMinHeap, __serialize, values, arginfo_class_Teds_StableMinHeap___serialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_StableMinHeap, __unserialize, arginfo_class_Teds_StableMinHeap___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -116,29 +137,32 @@ static const zend_function_entry class_Teds_StableMaxHeap_methods[] = {
 	ZEND_MALIAS(Teds_StableMinHeap, valid, valid, arginfo_class_Teds_StableMaxHeap_valid, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(Teds_StableMinHeap, clear, clear, arginfo_class_Teds_StableMaxHeap_clear, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StableMaxHeap, __set_state, arginfo_class_Teds_StableMaxHeap___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_MALIAS(Teds_StableMinHeap, values, values, arginfo_class_Teds_StableMaxHeap_values, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_StableMinHeap, __serialize, values, arginfo_class_Teds_StableMaxHeap___serialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_StableMaxHeap, __unserialize, arginfo_class_Teds_StableMaxHeap___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_StableMinHeap(zend_class_entry *class_entry_Teds_Iterator, zend_class_entry *class_entry_Teds_Countable)
+static zend_class_entry *register_class_Teds_StableMinHeap(zend_class_entry *class_entry_Teds_Iterator, zend_class_entry *class_entry_Teds_Values)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "StableMinHeap", class_Teds_StableMinHeap_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 2, class_entry_Teds_Iterator, class_entry_Teds_Countable);
+	zend_class_implements(class_entry, 2, class_entry_Teds_Iterator, class_entry_Teds_Values);
 
 	return class_entry;
 }
 
-static zend_class_entry *register_class_Teds_StableMaxHeap(zend_class_entry *class_entry_Teds_Iterator, zend_class_entry *class_entry_Teds_Countable)
+static zend_class_entry *register_class_Teds_StableMaxHeap(zend_class_entry *class_entry_Teds_Iterator, zend_class_entry *class_entry_Teds_Values)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "StableMaxHeap", class_Teds_StableMaxHeap_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 2, class_entry_Teds_Iterator, class_entry_Teds_Countable);
+	zend_class_implements(class_entry, 2, class_entry_Teds_Iterator, class_entry_Teds_Values);
 
 	return class_entry;
 }

--- a/teds_stablesortedlistmap.c
+++ b/teds_stablesortedlistmap.c
@@ -22,6 +22,7 @@
 #include "teds_stablesortedlistmap_arginfo.h"
 #include "teds_stablesortedlistmap.h"
 #include "teds_util.h"
+#include "teds_interfaces.h"
 #include "teds.h"
 // #include "ext/spl/spl_functions.h"
 #include "ext/spl/spl_engine.h"
@@ -35,7 +36,7 @@ zend_object_handlers teds_handler_StableSortedListMap;
 zend_class_entry *teds_ce_StableSortedListMap;
 
 typedef struct _teds_stablesortedlistmap_entry {
-	zval key;   /* TODO: Stores Z_NEXT - similar to https://github.com/php/php-src/pull/6588 */
+	zval key;
 	zval value;
 } teds_stablesortedlistmap_entry;
 
@@ -1163,7 +1164,7 @@ PHP_METHOD(Teds_StableSortedListMap, clear)
 PHP_MINIT_FUNCTION(teds_stablesortedlistmap)
 {
 	TEDS_MINIT_IGNORE_UNUSED();
-	teds_ce_StableSortedListMap = register_class_Teds_StableSortedListMap(zend_ce_aggregate, zend_ce_countable, php_json_serializable_ce, zend_ce_arrayaccess);
+	teds_ce_StableSortedListMap = register_class_Teds_StableSortedListMap(zend_ce_aggregate, teds_ce_Collection, php_json_serializable_ce);
 	teds_ce_StableSortedListMap->create_object = teds_stablesortedlistmap_new;
 
 	memcpy(&teds_handler_StableSortedListMap, &std_object_handlers, sizeof(zend_object_handlers));

--- a/teds_stablesortedlistmap.stub.php
+++ b/teds_stablesortedlistmap.stub.php
@@ -18,7 +18,7 @@ namespace Teds;
  * - Efficient at unserialization when entries are in sorted order.
  * - Slow at writes (linear time for each write) due to using insertion sort
  */
-final class StableSortedListMap implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+final class StableSortedListMap implements \IteratorAggregate, Collection, \JsonSerializable
 {
     /** Construct the StableSortedListMap from the keys and values of the Traversable/array. */
     public function __construct(iterable $iterator = []) {}
@@ -40,6 +40,12 @@ final class StableSortedListMap implements \IteratorAggregate, \Countable, \Json
     /** Construct the StableSortedListMap from the keys and values of the array ([[key1, value1], [key2, value2]]) */
     public static function __set_state(array $array): StableSortedListMap {}
 
+    // FIXME implement toArray
+    /**
+     * FIXME Returns array created by inserting values corresponding to keys of this map
+     * @implementation-alias Teds\StableSortedListMap::values
+     */
+    public function toArray(): array {}
     /** Returns a list of the values in order of insertion. */
     public function values(): array {}
 

--- a/teds_stablesortedlistmap_arginfo.h
+++ b/teds_stablesortedlistmap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9ad902b13ddcb8b3d4c8b93e9601ddf2ae11df16 */
+ * Stub hash: a5116b0b093840c0049dc2e05b40b8d9a30c40f0 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StableSortedListMap___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -33,6 +33,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StableSortedListMap___set_state, 0, 1, Teds\\StableSortedListMap, 0)
 	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_StableSortedListMap_toArray arginfo_class_Teds_StableSortedListMap_toPairs
 
 #define arginfo_class_Teds_StableSortedListMap_values arginfo_class_Teds_StableSortedListMap_toPairs
 
@@ -121,6 +123,7 @@ static const zend_function_entry class_Teds_StableSortedListMap_methods[] = {
 	ZEND_ME(Teds_StableSortedListMap, __serialize, arginfo_class_Teds_StableSortedListMap___serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StableSortedListMap, __unserialize, arginfo_class_Teds_StableSortedListMap___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StableSortedListMap, __set_state, arginfo_class_Teds_StableSortedListMap___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_MALIAS(Teds_StableSortedListMap, toArray, values, arginfo_class_Teds_StableSortedListMap_toArray, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StableSortedListMap, values, arginfo_class_Teds_StableSortedListMap_values, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StableSortedListMap, keys, arginfo_class_Teds_StableSortedListMap_keys, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StableSortedListMap, bottom, arginfo_class_Teds_StableSortedListMap_bottom, ZEND_ACC_PUBLIC)
@@ -140,14 +143,14 @@ static const zend_function_entry class_Teds_StableSortedListMap_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_StableSortedListMap(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+static zend_class_entry *register_class_Teds_StableSortedListMap(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Collection, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "StableSortedListMap", class_Teds_StableSortedListMap_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Collection, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_stablesortedlistset.c
+++ b/teds_stablesortedlistset.c
@@ -24,6 +24,7 @@
 #include "teds_stablesortedlistset_arginfo.h"
 #include "teds_stablesortedlistset.h"
 #include "teds_util.h"
+#include "teds_interfaces.h"
 #include "teds.h"
 // #include "ext/spl/spl_functions.h"
 #include "ext/spl/spl_engine.h"
@@ -832,7 +833,7 @@ PHP_METHOD(Teds_StableSortedListSet, clear)
 PHP_MINIT_FUNCTION(teds_stablesortedlistset)
 {
 	TEDS_MINIT_IGNORE_UNUSED();
-	teds_ce_StableSortedListSet = register_class_Teds_StableSortedListSet(zend_ce_aggregate, zend_ce_countable, php_json_serializable_ce);
+	teds_ce_StableSortedListSet = register_class_Teds_StableSortedListSet(zend_ce_aggregate, teds_ce_Values, php_json_serializable_ce);
 	teds_ce_StableSortedListSet->create_object = teds_stablesortedlistset_new;
 
 	memcpy(&teds_handler_StableSortedListSet, &std_object_handlers, sizeof(zend_object_handlers));

--- a/teds_stablesortedlistset.stub.php
+++ b/teds_stablesortedlistset.stub.php
@@ -17,7 +17,7 @@ namespace Teds;
  * - Good performance when writes are infrequent.
  * - Linear time needed for each write due to using insertion sort.
  */
-final class StableSortedListSet implements \IteratorAggregate, \Countable, \JsonSerializable
+final class StableSortedListSet implements \IteratorAggregate, Values, \JsonSerializable
 {
     /** Construct the StableSortedListSet from the keys and values of the Traversable/array. */
     public function __construct(iterable $iterator = []) {}

--- a/teds_stablesortedlistset_arginfo.h
+++ b/teds_stablesortedlistset_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f906b5847f45b84f1e68ffe1fdbcbd83d7185f61 */
+ * Stub hash: 4048ea9420ec8083a06618d08f190695ac7a6b68 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StableSortedListSet___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -88,14 +88,14 @@ static const zend_function_entry class_Teds_StableSortedListSet_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_StableSortedListSet(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable)
+static zend_class_entry *register_class_Teds_StableSortedListSet(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Values, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "StableSortedListSet", class_Teds_StableSortedListSet_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Values, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_strictmap.c
+++ b/teds_strictmap.c
@@ -23,6 +23,7 @@
 #include "teds_strictmap_arginfo.h"
 #include "teds_strictmap.h"
 #include "teds_util.h"
+#include "teds_interfaces.h"
 #include "teds.h"
 // #include "ext/spl/spl_functions.h"
 #include "ext/spl/spl_engine.h"
@@ -1162,7 +1163,7 @@ PHP_METHOD(Teds_StrictMap, clear)
 PHP_MINIT_FUNCTION(teds_strictmap)
 {
 	TEDS_MINIT_IGNORE_UNUSED();
-	teds_ce_StrictMap = register_class_Teds_StrictMap(zend_ce_aggregate, zend_ce_countable, php_json_serializable_ce, zend_ce_arrayaccess);
+	teds_ce_StrictMap = register_class_Teds_StrictMap(zend_ce_aggregate, teds_ce_Collection, php_json_serializable_ce);
 	teds_ce_StrictMap->create_object = teds_strictmap_new;
 
 	memcpy(&teds_handler_StrictMap, &std_object_handlers, sizeof(zend_object_handlers));

--- a/teds_strictmap.stub.php
+++ b/teds_strictmap.stub.php
@@ -12,7 +12,7 @@ namespace Teds;
  * This is a map where entries for keys of any type can be inserted if they are `!==` to other keys.
  * This uses `Teds\strict_hash`
  */
-final class StrictMap implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+final class StrictMap implements \IteratorAggregate, Collection, \JsonSerializable
 {
     /** Construct the StrictMap from the keys and values of the Traversable/array. */
     public function __construct(iterable $iterator = []) {}
@@ -35,6 +35,12 @@ final class StrictMap implements \IteratorAggregate, \Countable, \JsonSerializab
     /** Construct the StrictMap from the keys and values of the array ([[key1, value1], [key2, value2]]) */
     public static function __set_state(array $array): StrictMap {}
 
+    // FIXME implement toArray
+    /**
+     * FIXME Returns array created by inserting values corresponding to keys of this map
+     * @implementation-alias Teds\StableSortedListMap::values
+     */
+    public function toArray(): array {}
     /** Returns a list of the values in order of insertion. */
     public function values(): array {}
 

--- a/teds_strictmap_arginfo.h
+++ b/teds_strictmap_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 84722fd8dbfdd7e9df6552eaca689b1e4ea27694 */
+ * Stub hash: 956ff49daf1ee2652b5148e528c00fb92021f573 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictMap___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -33,6 +33,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictMap___set_state, 0, 1, Teds\\StrictMap, 0)
 	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_StrictMap_toArray arginfo_class_Teds_StrictMap_toPairs
 
 #define arginfo_class_Teds_StrictMap_values arginfo_class_Teds_StrictMap_toPairs
 
@@ -79,6 +81,7 @@ ZEND_METHOD(Teds_StrictMap, fromPairs);
 ZEND_METHOD(Teds_StrictMap, __serialize);
 ZEND_METHOD(Teds_StrictMap, __unserialize);
 ZEND_METHOD(Teds_StrictMap, __set_state);
+ZEND_METHOD(Teds_StableSortedListMap, values);
 ZEND_METHOD(Teds_StrictMap, values);
 ZEND_METHOD(Teds_StrictMap, keys);
 ZEND_METHOD(Teds_StrictMap, offsetGet);
@@ -101,6 +104,7 @@ static const zend_function_entry class_Teds_StrictMap_methods[] = {
 	ZEND_ME(Teds_StrictMap, __serialize, arginfo_class_Teds_StrictMap___serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StrictMap, __unserialize, arginfo_class_Teds_StrictMap___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StrictMap, __set_state, arginfo_class_Teds_StrictMap___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_MALIAS(Teds_StableSortedListMap, toArray, values, arginfo_class_Teds_StrictMap_toArray, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StrictMap, values, arginfo_class_Teds_StrictMap_values, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StrictMap, keys, arginfo_class_Teds_StrictMap_keys, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_StrictMap, offsetGet, arginfo_class_Teds_StrictMap_offsetGet, ZEND_ACC_PUBLIC)
@@ -114,14 +118,14 @@ static const zend_function_entry class_Teds_StrictMap_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_StrictMap(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+static zend_class_entry *register_class_Teds_StrictMap(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Collection, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "StrictMap", class_Teds_StrictMap_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Collection, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_strictset.c
+++ b/teds_strictset.c
@@ -31,6 +31,7 @@
 #include "teds_strictset_arginfo.h"
 #include "teds_strictset.h"
 #include "teds_util.h"
+#include "teds_interfaces.h"
 #include "teds.h"
 // #include "ext/spl/spl_functions.h"
 #include "ext/spl/spl_engine.h"
@@ -835,7 +836,7 @@ PHP_METHOD(Teds_StrictSet, clear)
 PHP_MINIT_FUNCTION(teds_strictset)
 {
 	TEDS_MINIT_IGNORE_UNUSED();
-	teds_ce_StrictSet = register_class_Teds_StrictSet(zend_ce_aggregate, zend_ce_countable, php_json_serializable_ce);
+	teds_ce_StrictSet = register_class_Teds_StrictSet(zend_ce_aggregate, teds_ce_Values, php_json_serializable_ce);
 	teds_ce_StrictSet->create_object = teds_strictset_new;
 
 	memcpy(&teds_handler_StrictSet, &std_object_handlers, sizeof(zend_object_handlers));

--- a/teds_strictset.stub.php
+++ b/teds_strictset.stub.php
@@ -6,16 +6,16 @@
 namespace Teds;
 
 /**
- * Strict set which can contain any value type.
- * **This is a work in progress.** Iteration will not work as expected if elements are removed during iteration, and hash lookups haven't been implemented yet, so this is inefficient for large maps (scans the entire map).
+ * Strict set which can contain any value type, based on a hash table.
+ * **Iteration is a work in progress.** Iteration will not work as expected if elements are removed during iteration.
  *
- * This is a set where values of any type can be inserted if they are `!==` to other keys.
+ * This is a set where values of any type can be inserted if they are `!==` to other keys and have different values of strict_hash.
  * This uses `Teds\strict_hash`.
  *
  * ArrayAccess is not implemented because `$x[$item] = $value` is meaningless
  * and there could be multiple desired meetings of `$value = $x[$item];`
  */
-final class StrictSet implements \IteratorAggregate, \Countable, \JsonSerializable
+final class StrictSet implements \IteratorAggregate, Values, \JsonSerializable
 {
     /** Construct the StrictSet from the values of the Traversable/array, ignoring keys. */
     public function __construct(iterable $iterator = []) {}

--- a/teds_strictset_arginfo.h
+++ b/teds_strictset_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: cedd6a22a30d665f4f98ed12d736077c28499d64 */
+ * Stub hash: eebe72c4c6d8f2cfcb1196edc66385bc241be913 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictSet___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -71,14 +71,14 @@ static const zend_function_entry class_Teds_StrictSet_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_StrictSet(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable)
+static zend_class_entry *register_class_Teds_StrictSet(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_Values, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "StrictSet", class_Teds_StrictSet_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_Values, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/teds_vector.stub.php
+++ b/teds_vector.stub.php
@@ -14,7 +14,7 @@ namespace Teds;
  *
  * Attempting to read or write values outside of the range of values with `*get`/`*set` methods will throw at runtime.
  */
-final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable, \ArrayAccess
+final class Vector implements \IteratorAggregate, ListInterface, \JsonSerializable
 {
     /**
      * Construct a Vector from an iterable.
@@ -69,6 +69,12 @@ final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable,
     public function pop(): mixed {}
 
     public function toArray(): array {}
+
+    /**
+     * @implementation-alias Teds\Vector::toArray
+     * @override for Sequence::values()
+     */
+    public function values(): array {}
     // Strictly typed, unlike offsetGet/offsetSet
     public function get(int $offset): mixed {}
     public function set(int $offset, mixed $value): void {}
@@ -80,9 +86,14 @@ final class Vector implements \IteratorAggregate, \Countable, \JsonSerializable,
     public function offsetGet(mixed $offset): mixed {}
 
     /**
-     * Returns true if `0 <= (int)$offset && (int)$offset < $this->count().
+     * Returns true if `0 <= (int)$offset && (int)$offset < $this->count()
+     * AND the value of offsetGet is non-null.
      */
     public function offsetExists(mixed $offset): bool {}
+    /**
+     * Returns true if `is_int($offset) && 0 <= $offset && $offset < $this->count()
+     */
+    public function containsKey(mixed $offset): bool {}
 
     /**
      * Sets the value at offset (int)$offset to $value

--- a/teds_vector_arginfo.h
+++ b/teds_vector_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 3bf1177dfda6d88a36b1e1d8a43a5a2fd6149b98 */
+ * Stub hash: fd28de9c078787a6d758020c05e06fe2e3040bea */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Vector___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
@@ -50,6 +50,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_Vector_toArray arginfo_class_Teds_Vector___serialize
 
+#define arginfo_class_Teds_Vector_values arginfo_class_Teds_Vector___serialize
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -66,6 +68,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_offsetExists, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+
+#define arginfo_class_Teds_Vector_containsKey arginfo_class_Teds_Vector_offsetExists
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Vector_offsetSet, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
@@ -113,6 +117,7 @@ ZEND_METHOD(Teds_Vector, get);
 ZEND_METHOD(Teds_Vector, set);
 ZEND_METHOD(Teds_Vector, offsetGet);
 ZEND_METHOD(Teds_Vector, offsetExists);
+ZEND_METHOD(Teds_Vector, containsKey);
 ZEND_METHOD(Teds_Vector, offsetSet);
 ZEND_METHOD(Teds_Vector, offsetUnset);
 ZEND_METHOD(Teds_Vector, indexOf);
@@ -137,10 +142,12 @@ static const zend_function_entry class_Teds_Vector_methods[] = {
 	ZEND_ME(Teds_Vector, push, arginfo_class_Teds_Vector_push, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, pop, arginfo_class_Teds_Vector_pop, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, toArray, arginfo_class_Teds_Vector_toArray, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(Teds_Vector, values, toArray, arginfo_class_Teds_Vector_values, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, get, arginfo_class_Teds_Vector_get, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, set, arginfo_class_Teds_Vector_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, offsetGet, arginfo_class_Teds_Vector_offsetGet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, offsetExists, arginfo_class_Teds_Vector_offsetExists, ZEND_ACC_PUBLIC)
+	ZEND_ME(Teds_Vector, containsKey, arginfo_class_Teds_Vector_containsKey, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, offsetSet, arginfo_class_Teds_Vector_offsetSet, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, offsetUnset, arginfo_class_Teds_Vector_offsetUnset, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_Vector, indexOf, arginfo_class_Teds_Vector_indexOf, ZEND_ACC_PUBLIC)
@@ -151,14 +158,14 @@ static const zend_function_entry class_Teds_Vector_methods[] = {
 	ZEND_FE_END
 };
 
-static zend_class_entry *register_class_Teds_Vector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Countable, zend_class_entry *class_entry_JsonSerializable, zend_class_entry *class_entry_ArrayAccess)
+static zend_class_entry *register_class_Teds_Vector(zend_class_entry *class_entry_IteratorAggregate, zend_class_entry *class_entry_Teds_ListInterface, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "Teds", "Vector", class_Teds_Vector_methods);
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
 	class_entry->ce_flags |= ZEND_ACC_FINAL;
-	zend_class_implements(class_entry, 4, class_entry_IteratorAggregate, class_entry_Countable, class_entry_JsonSerializable, class_entry_ArrayAccess);
+	zend_class_implements(class_entry, 3, class_entry_IteratorAggregate, class_entry_Teds_ListInterface, class_entry_JsonSerializable);
 
 	return class_entry;
 }

--- a/tests/IntVector/push_pop.phpt
+++ b/tests/IntVector/push_pop.phpt
@@ -32,7 +32,7 @@ echo "After pushing variadic args\n";
 $it->push(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 echo json_encode($it), "\n";
 printf("count=%d capacity=%d\n", count($it), $it->capacity());
-$it->push(1, -1, 1, 567, 123, 11, 11);
+$it->pushInts(1, -1, 1, 567, 123, 11, 11);
 echo json_encode($it), "\n";
 printf("count=%d capacity=%d\n", count($it), $it->capacity());
 

--- a/tests/IntVector/setValueAt.phpt
+++ b/tests/IntVector/setValueAt.phpt
@@ -20,7 +20,8 @@ expect_throws(fn() => $it->set(0, strtoupper('value')));
 echo "Test short vector\n";
 $it = new Teds\IntVector([1, 2, 3]);
 $it->set(0, 123);
-$it->offsetSet(2, 123);
+$it->setInt(1, 124);
+$it->offsetSet(2, 125);
 echo json_encode($it), "\n";
 expect_throws(fn() => $it->set(-1, 123));
 expect_throws(fn() => $it->set(3, 151));
@@ -31,10 +32,10 @@ expect_throws(fn() => $it->set(PHP_INT_MAX, 123));
 --EXPECT--
 Test empty vector
 Caught OutOfBoundsException: Index out of range
-Caught TypeError: Teds\IntVector::set(): Argument #2 ($value) must be of type int, string given
+Caught TypeError: Illegal Teds\IntVector value type string
 Test short vector
-[123,2,123]
+[123,124,125]
 Caught OutOfBoundsException: Index out of range
 Caught OutOfBoundsException: Index out of range
-Caught TypeError: Teds\IntVector::set(): Argument #2 ($value) must be of type int, string given
+Caught TypeError: Illegal Teds\IntVector value type string
 Caught OutOfBoundsException: Index out of range

--- a/tests/StableHeap/serialization.phpt
+++ b/tests/StableHeap/serialization.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Teds\StableMinHeap can be serialized and unserialized
+--FILE--
+<?php
+function create_val(string $k) {
+    return "val$k";
+}
+
+$it = new Teds\StableMinHeap(array_map('create_val', ['a', 'c', 'b', 'id', 'ue', 'd']));
+try {
+    $it->dynamicProp = 123;
+} catch (Throwable $t) {
+    printf("Caught %s: %s\n", $t::class, $t->getMessage());
+}
+$ser = serialize($it);
+echo $ser, "\n";
+foreach ($it as $key => $value) {
+    echo "Entry:\n";
+    var_dump($key, $value);
+}
+var_dump(unserialize($ser));
+foreach (unserialize($ser) as $key => $value) {
+    echo "Entry:\n";
+    var_dump($key, $value);
+}
+?>
+--EXPECT--
+Caught Error: Cannot create dynamic property Teds\StableMinHeap::$dynamicProp
+O:18:"Teds\StableMinHeap":6:{i:0;s:4:"vala";i:1;s:4:"valb";i:2;s:4:"valc";i:3;s:5:"valid";i:4;s:5:"value";i:5;s:4:"vald";}
+Entry:
+string(4) "vala"
+string(4) "vala"
+Entry:
+string(4) "valb"
+string(4) "valb"
+Entry:
+string(4) "valc"
+string(4) "valc"
+Entry:
+string(4) "vald"
+string(4) "vald"
+Entry:
+string(5) "valid"
+string(5) "valid"
+Entry:
+string(5) "value"
+string(5) "value"
+object(Teds\StableMinHeap)#3 (6) {
+  [0]=>
+  string(4) "vala"
+  [1]=>
+  string(4) "valb"
+  [2]=>
+  string(4) "valc"
+  [3]=>
+  string(5) "valid"
+  [4]=>
+  string(5) "value"
+  [5]=>
+  string(4) "vald"
+}
+Entry:
+string(4) "vala"
+string(4) "vala"
+Entry:
+string(4) "valb"
+string(4) "valb"
+Entry:
+string(4) "valc"
+string(4) "valc"
+Entry:
+string(4) "vald"
+string(4) "vald"
+Entry:
+string(5) "valid"
+string(5) "valid"
+Entry:
+string(5) "value"
+string(5) "value"


### PR DESCRIPTION
`list` is already a reserved keyword in php and can't be used.
(`list($a) = $values;`)