### PR TITLE
1.0.0: Fix bugs in LowMemoryVector, Add 32-bit tests

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,8 @@
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
 * BREAKING CHANGES: Rename datastructures and interfaces for consistency. Change definitions of interfaces/remove interfaces.
+* BREAKING CHANGES: Fix incorrect serialization/unserialization result of LowMemoryVector for boolean/null. Incompatible with older releases.
+* BUGFIX: Fix converting LowMemoryVector of floats to an array (they were unintentionally converted to integers).
  </notes>
  <contents>
   <dir name="/">

--- a/tests/IntVector/promote_32bit.phpt
+++ b/tests/IntVector/promote_32bit.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Teds\IntVector promote storage type
+--SKIPIF--
+<?php if (PHP_INT_SIZE >= 8) { echo "skip 32-bit only\n"; } ?>
+--FILE--
+<?php
+// discards keys
+function dump_index_of(Teds\IntVector $it, int $value)  {
+    printf("indexOf %s: %s\n", json_encode($value), json_encode($it->indexOf($value)));
+}
+$it = new Teds\IntVector();
+$it->push(123);
+echo json_encode($it), "\n";
+echo json_encode(clone $it), "\n";
+$it->push(PHP_INT_MAX);
+echo json_encode($it), "\n";
+echo json_encode(clone $it), "\n";
+unset($it);
+echo "Test promote int32 to mixed\n";
+$it = new Teds\IntVector();
+$it->push(-123);
+echo json_encode($it), "\n";
+dump_index_of($it, -123);
+dump_index_of($it, -256 - 123);
+unset($it);
+?>
+--EXPECT--
+[123]
+[123]
+[123,2147483647]
+[123,2147483647]
+Test promote int32 to mixed
+[-123]
+indexOf -123: 0
+indexOf -379: null

--- a/tests/IntVector/serialization_64_32bit.phpt
+++ b/tests/IntVector/serialization_64_32bit.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Teds\IntVector can be serialized and unserialized
+--SKIPIF--
+<?php if (PHP_INT_SIZE >= 8) echo "skip 32-bit only\n"; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../encode_raw_string.inc';
+set_error_handler(function ($errno, $msg) { echo "Warning: $msg\n"; });
+
+function test_serialize_values(...$values) {
+    $vec = new Teds\IntVector();
+    try {
+        foreach ($values as $v) { $vec[] = $v; }
+    } catch (TypeError $e) {
+        echo "Caught {$e->getMessage()}\n";
+        return;
+    }
+    echo json_encode($vec), "\n";
+    $ser = serialize($vec);
+    echo encode_raw_string($ser), "\n";
+    echo "Unserialize: ", json_encode(unserialize($ser)), "\n\n";
+}
+test_serialize_values(0, PHP_INT_MAX, PHP_INT_MIN);
+test_serialize_values(0x7fff_ffff);
+test_serialize_values(0x8000_0000);
+test_serialize_values(-0x8000_0000, -1);
+test_serialize_values(-0x8000_0001, 1);
+?>
+--EXPECT--
+[0,2147483647,-2147483648]
+"O:14:\"Teds\\IntVector\":2:{i:0;i:3;i:1;s:12:\"\x00\x00\x00\x00\xff\xff\xff\x7f\x00\x00\x00\x80\";}"
+Unserialize: [0,2147483647,-2147483648]
+
+[2147483647]
+"O:14:\"Teds\\IntVector\":2:{i:0;i:3;i:1;s:4:\"\xff\xff\xff\x7f\";}"
+Unserialize: [2147483647]
+
+Caught Illegal Teds\IntVector value type float
+Caught Illegal Teds\IntVector value type float
+Caught Illegal Teds\IntVector value type float

--- a/tests/LowMemoryVector/bitsetSerialization.phpt
+++ b/tests/LowMemoryVector/bitsetSerialization.phpt
@@ -20,31 +20,31 @@ test_low_memory_vector(true,  false, true,  true,  false, true,  false, true,  t
 test_low_memory_vector(true,  false, true,  true,  false, true,  false, true,  true,  null);
 test_low_memory_vector(null, null, null, null, true, false, null, true);
 ?>
---EXPECTF--
+--EXPECT--
 Original: [true,true,true,true,true,true,true,true]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\x00\xff\";}"
-[false,false,false,false,false,false,false,false]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\xff\x00\";}"
+[true,true,true,true,true,true,true,true]
 
 Original: [false,false,false,false,false,false,false,false]
 "O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\x00\x00\";}"
 [false,false,false,false,false,false,false,false]
 
 Original: [true,false,true,true,false,true,false,true]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\x00\xad\";}"
-[false,false,false,false,false,false,false,false]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\xad\x00\";}"
+[true,false,true,true,false,true,false,true]
 
 Original: [true,false,true,true,false,true,false]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\x07-\";}"
-[true,true,true,false,false,false,false]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"-\x01\";}"
+[true,false,true,true,false,true,false]
 
 Original: [true,false,true,true,false,true,false,true,true]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:3:\"\x01\x01\xd6\";}"
-[true,true,false,false,false,false,false,false,false]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:3:\"\xad\x01\x07\";}"
+[true,false,true,true,false,true,false,true,true]
 
 Original: [true,false,true,true,false,true,false,true,true,null]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:1;i:1;s:4:\"\x02\x0b\xef~\";}"
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:1;i:1;s:4:\"\xfb\xee\x07\x02\";}"
 [true,false,true,true,false,true,false,true,true,null]
 
 Original: [null,null,null,null,true,false,null,true]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:1;i:1;s:3:\"\x00U\xdb\";}"
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:1;i:1;s:3:\"U\xdb\x00\";}"
 [null,null,null,null,true,false,null,true]

--- a/tests/LowMemoryVector/promote_32bit.phpt
+++ b/tests/LowMemoryVector/promote_32bit.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Teds\LowMemoryVector promote storage type
+--SKIPIF--
+<?php if (PHP_INT_SIZE >= 8) { echo "skip 32-bit only\n"; } ?>
+--FILE--
+<?php
+// discards keys
+function dump_index_of(Teds\LowMemoryVector $it, $value)  {
+    printf("indexOf %s: %s\n", json_encode($value), json_encode($it->indexOf($value)));
+}
+$it = new Teds\LowMemoryVector();
+$it->push(123);
+echo json_encode($it), "\n";
+echo json_encode(clone $it), "\n";
+$it->push(PHP_INT_MAX);
+echo json_encode($it), "\n";
+echo json_encode(clone $it), "\n";
+$it->push(strtoupper('test'));
+echo json_encode($it), "\n";
+echo json_encode(clone $it), "\n";
+unset($it);
+echo "Test promote int32 to mixed\n";
+$it = new Teds\LowMemoryVector();
+$it->push(-123);
+echo json_encode($it), "\n";
+dump_index_of($it, -123);
+dump_index_of($it, -256 - 123);
+$it->push(strtoupper('test'));
+echo json_encode($it), "\n";
+dump_index_of($it, -123);
+dump_index_of($it, 'TEST');
+unset($it);
+?>
+--EXPECT--
+[123]
+[123]
+[123,2147483647]
+[123,2147483647]
+[123,2147483647,"TEST"]
+[123,2147483647,"TEST"]
+Test promote int32 to mixed
+[-123]
+indexOf -123: 0
+indexOf -379: null
+[-123,"TEST"]
+indexOf -123: 0
+indexOf "TEST": 1

--- a/tests/LowMemoryVector/serialization.phpt
+++ b/tests/LowMemoryVector/serialization.phpt
@@ -54,7 +54,7 @@ Unserialized: object(Teds\LowMemoryVector)#3 (1) {
   int(0)
 }
 [null]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:1;i:1;s:2:\"\x01\x01\";}"
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:1;i:1;s:2:\"\x01\x03\";}"
 
 Unserialized: object(Teds\LowMemoryVector)#3 (1) {
   [0]=>

--- a/tests/LowMemoryVector/serialization_64_32bit.phpt
+++ b/tests/LowMemoryVector/serialization_64_32bit.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Teds\LowMemoryVector can be serialized and unserialized
 --SKIPIF--
-<?php if (PHP_INT_SIZE < 8) echo "skip 64-bit only\n"; ?>
+<?php if (PHP_INT_SIZE >= 8) echo "skip 32-bit only\n"; ?>
 --FILE--
 <?php
 require_once __DIR__ . '/../encode_raw_string.inc';
@@ -20,15 +20,15 @@ test_serialize_values(1.5);
 test_serialize_values(true, false, false, true, true);
 test_serialize_values(true, false, null, null, true);
 test_serialize_values(0x7fff_ffff);
-test_serialize_values(0x8000_0000);
-test_serialize_values(-0x8000_0000, -1);
+test_serialize_values(0x8000_0000);  // due to the lack of strict_types this float is converted to an int and overflows in php. https://wiki.php.net/rfc/implicit-float-int-deprecate does not affect this.
+test_serialize_values(-0x8000_0000, -1);  // this is serialized as a float
 test_serialize_values(-0x8000_0001, 1);
 test_serialize_values(0x0102030405060708, 0x7ffefdfcfbfaf0f9, 0);
 ?>
 --EXPECT--
-[0,9223372036854775807,-9223372036854775808]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:5;i:1;s:24:\"\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\x7f\x00\x00\x00\x00\x00\x00\x00\x80\";}"
-Unserialize: [0,9223372036854775807,-9223372036854775808]
+[0,2147483647,-2147483648]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:4;i:1;s:12:\"\x00\x00\x00\x00\xff\xff\xff\x7f\x00\x00\x00\x80\";}"
+Unserialize: [0,2147483647,-2147483648]
 
 [1.5]
 "O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:6;i:1;s:8:\"\x00\x00\x00\x00\x00\x00\xf8?\";}"
@@ -47,17 +47,17 @@ Unserialize: [true,false,null,null,true]
 Unserialize: [2147483647]
 
 [2147483648]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:5;i:1;s:8:\"\x00\x00\x00\x80\x00\x00\x00\x00\";}"
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:6;i:1;s:8:\"\x00\x00\x00\x00\x00\x00\xe0A\";}"
 Unserialize: [2147483648]
 
 [-2147483648,-1]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:4;i:1;s:8:\"\x00\x00\x00\x80\xff\xff\xff\xff\";}"
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:7;i:1;a:2:{i:0;d:-2147483648;i:1;i:-1;}}"
 Unserialize: [-2147483648,-1]
 
 [-2147483649,1]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:5;i:1;s:16:\"\xff\xff\xff\x7f\xff\xff\xff\xff\x01\x00\x00\x00\x00\x00\x00\x00\";}"
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:7;i:1;a:2:{i:0;d:-2147483649;i:1;i:1;}}"
 Unserialize: [-2147483649,1]
 
-[72623859790382856,9223088349902467321,0]
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:5;i:1;s:24:\"\x08\x07\x06\x05\x04\x03\x02\x01\xf9\xf0\xfa\xfb\xfc\xfd\xfe\x7f\x00\x00\x00\x00\x00\x00\x00\x00\";}"
-Unserialize: [72623859790382856,9223088349902467321,0]
+[72623859790382850,9.223088349902467e+18,0]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:7;i:1;a:3:{i:0;d:72623859790382850;i:1;d:9.223088349902467E+18;i:2;i:0;}}"
+Unserialize: [72623859790382850,9.223088349902467e+18,0]

--- a/tests/LowMemoryVector/specializations.phpt
+++ b/tests/LowMemoryVector/specializations.phpt
@@ -7,7 +7,7 @@ function my_error_handler($errno, $errmsg) { echo "Warning: $errmsg\n"; }
 set_error_handler('my_error_handler');
 
 function test_low_memory_vector($value, ...$extra) {
-    printf("test_low_memory_vector of %s\n", json_encode($value));
+    printf("test_low_memory_vector of %s\n", json_encode([$value, $value]));
     $vec = new Teds\LowMemoryVector();
     $vec->push($value);
     $vec->push($value);
@@ -48,7 +48,7 @@ foreach ([
 }
 ?>
 --EXPECTF--
-test_low_memory_vector of 1
+test_low_memory_vector of [1,1]
 "O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:2;i:1;s:2:\"\x01\x01\";}"
 Unserialized: [1,1]
 1: indexOf=0 contains=true
@@ -61,9 +61,9 @@ Iterable values:[1,1]
 Appending extra values
 After appending extra values: [1,1,2,65537,%d]
 
-test_low_memory_vector of 1.5
+test_low_memory_vector of [1.5,1.5]
 "O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:6;i:1;s:16:\"\x00\x00\x00\x00\x00\x00\xf8?\x00\x00\x00\x00\x00\x00\xf8?\";}"
-Unserialized: [1,1]
+Unserialized: [1.5,1.5]
 1.5: indexOf=0 contains=true
 -2.5: indexOf=null contains=false
 1: indexOf=null contains=false
@@ -74,7 +74,7 @@ Iterable values:[1.5,1.5]
 Appending extra values
 After appending extra values: [1.5,1.5,-2.5,1,%d]
 
-test_low_memory_vector of 4660
+test_low_memory_vector of [4660,4660]
 "O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:3;i:1;s:4:\"4\x124\x12\";}"
 Unserialized: [4660,4660]
 4660: indexOf=0 contains=true
@@ -87,7 +87,7 @@ Iterable values:[4660,4660]
 Appending extra values
 After appending extra values: [4660,4660,-21537,true,%d]
 
-test_low_memory_vector of 305419896
+test_low_memory_vector of [305419896,305419896]
 "O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:4;i:1;s:8:\"xV4\x12xV4\x12\";}"
 Unserialized: [305419896,305419896]
 305419896: indexOf=0 contains=true
@@ -99,9 +99,9 @@ Iterable values:[305419896,305419896]
 Appending extra values
 After appending extra values: [305419896,305419896,-21537,%d]
 
-test_low_memory_vector of true
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\x02\x03\";}"
-Unserialized: [false,true]
+test_low_memory_vector of [true,true]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\x03\x06\";}"
+Unserialized: [true,true]
 true: indexOf=0 contains=true
 false: indexOf=null contains=false
 null: indexOf=null contains=false
@@ -113,9 +113,9 @@ Iterable values:[true,true]
 Appending extra values
 After appending extra values: [true,true,false,null,"_x",%d]
 
-test_low_memory_vector of false
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\x02\x00\";}"
-Unserialized: [false,true]
+test_low_memory_vector of [false,false]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:0;i:1;s:2:\"\x00\x06\";}"
+Unserialized: [false,false]
 false: indexOf=0 contains=true
 true: indexOf=null contains=false
 Contents:bool(false)
@@ -124,8 +124,8 @@ Iterable values:[false,false]
 Appending extra values
 After appending extra values: [false,false,true]
 
-test_low_memory_vector of null
-"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:1;i:1;s:2:\"\x02\x05\";}"
+test_low_memory_vector of [null,null]
+"O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:1;i:1;s:2:\"\x05\x02\";}"
 Unserialized: [null,null]
 null: indexOf=0 contains=true
 false: indexOf=null contains=false
@@ -138,7 +138,7 @@ Iterable values:[null,null]
 Appending extra values
 After appending extra values: [null,null,false,true,"_x",%d]
 
-test_low_memory_vector of "_a"
+test_low_memory_vector of ["_a","_a"]
 "O:20:\"Teds\\LowMemoryVector\":2:{i:0;i:7;i:1;a:2:{i:0;s:2:\"_a\";i:1;s:2:\"_a\";}}"
 Unserialized: ["_a","_a"]
 "_a": indexOf=0 contains=true

--- a/tests/misc/strict_hash_32bit.phpt
+++ b/tests/misc/strict_hash_32bit.phpt
@@ -1,0 +1,173 @@
+--TEST--
+Test strict_hash() function
+--SKIPIF--
+<?php if (PHP_INT_SIZE >= 8) echo "skip 32-bit only\n"; ?>
+--FILE--
+<?php
+
+$zero = 0.0;
+$values = [
+    null,
+    false,
+    true,
+    -1,
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    16,
+    24,
+    PHP_INT_MAX,
+    PHP_INT_MIN,
+    0.0,
+    -0.0,  // Deliberately return the same hash as 0.0, because php has 0.0 === -0.0 and it's equivalent in *almost* all ways, apart from 1 / -0.0
+    [0.0],
+    [-0.0],  // Deliberately return the same hash as 0.0, because php has 0.0 === -0.0 and it's equivalent in *almost* all ways, apart from 1 / -0.0
+    1.5,
+    1.2,
+    2.0,
+    3.0,
+    1234567.0,
+    '',
+    'a',
+    'b',
+    [],
+    [1],
+    [1 => 1],
+    ['a' => 1],
+    new stdClass(),
+    new stdClass(),
+    function () {},
+    function () {},
+    STDIN,
+    INF,
+    -INF,
+    NAN,
+    -NAN,
+    fdiv($zero, $zero),
+];
+
+$all = [];
+foreach ($values as $value) {
+    var_dump($value);
+    $hash = Teds\strict_hash($value);
+    printf("=> 0x%016x", $hash);
+    if (isset($all[$hash])) {
+        echo " (Already saw)";
+    }
+    echo "\n";
+    $all[$hash] = $value;
+}
+?>
+--EXPECT--
+NULL
+=> 0x000000005a0a0214
+bool(false)
+=> 0x0000000033632f72
+bool(true)
+=> 0x000000000bbc5cd0
+int(-1)
+=> 0x0000000027a7d2a1
+int(0)
+=> 0x0000000000000000
+int(1)
+=> 0x00000000d8582d5e
+int(2)
+=> 0x00000000b1b15abc
+int(3)
+=> 0x000000008a0a881a
+int(4)
+=> 0x000000006263b578
+int(5)
+=> 0x000000003bbce2d6
+int(6)
+=> 0x0000000014151035
+int(7)
+=> 0x00000000ec6d3d93
+int(8)
+=> 0x00000000c5c66af1
+int(16)
+=> 0x000000008b8dd5e2
+int(24)
+=> 0x00000000505440d4
+int(2147483647)
+=> 0x00000000931bb1fb
+int(-2147483648)
+=> 0x00000000938b21a6
+float(0)
+=> 0x0000000095c6e4ea
+float(-0)
+=> 0x0000000095c6e4ea (Already saw)
+array(1) {
+  [0]=>
+  float(0)
+}
+=> 0x0000000073121d71
+array(1) {
+  [0]=>
+  float(-0)
+}
+=> 0x0000000073121d71 (Already saw)
+float(1.5)
+=> 0x0000000009921f06
+float(1.2)
+=> 0x000000008cc75d02
+float(2)
+=> 0x00000000c2fc3a76
+float(3)
+=> 0x0000000060c201e1
+float(1234567)
+=> 0x00000000929ef487
+string(0) ""
+=> 0x000000008d0e4e35
+string(1) "a"
+=> 0x00000000e9170dca
+string(1) "b"
+=> 0x00000000c2703a28
+array(0) {
+}
+=> 0x00000000e4148a2e
+array(1) {
+  [0]=>
+  int(1)
+}
+=> 0x00000000aa55ec95
+array(1) {
+  [1]=>
+  int(1)
+}
+=> 0x000000005da54c37
+array(1) {
+  ["a"]=>
+  int(1)
+}
+=> 0x00000000fe809758
+object(stdClass)#1 (0) {
+}
+=> 0x00000000322d2cab
+object(stdClass)#2 (0) {
+}
+=> 0x000000000b865909
+object(Closure)#3 (0) {
+}
+=> 0x00000000e3de8667
+object(Closure)#4 (0) {
+}
+=> 0x00000000bc37b4c5
+resource(1) of type (stream)
+=> 0x00000000ac0e6043
+float(INF)
+=> 0x000000009802af26
+float(-INF)
+=> 0x00000000f26e5b3d
+float(NAN)
+=> 0x00000000903422a8
+float(NAN)
+=> 0x00000000903422a8 (Already saw)
+float(NAN)
+=> 0x00000000903422a8 (Already saw)

--- a/tests/misc/strict_hash_array_recursion_32bit.phpt
+++ b/tests/misc/strict_hash_array_recursion_32bit.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Test strict_hash() function on recursive arrays
+--SKIPIF--
+<?php if (PHP_INT_SIZE >= 8) echo "skip 32-bit only\n"; ?>
+--FILE--
+<?php
+
+$values = [];
+// Should hash the same way for different but equivalent array instances
+for ($i = 0; $i < 2; $i++) {
+    $x = [];
+    $x[0] = &$x;
+    var_dump($x);
+    var_dump(Teds\strict_hash($x));
+    $x[] = 123;
+    var_dump(Teds\strict_hash($x));
+    $values[] = &$x;
+    unset($x);
+}
+echo "Recursive arrays hashed in a predictable way\n";
+var_dump($values);
+var_dump(Teds\strict_hash($values));
+$values[0] = &$values[1];
+// NOTE: This currently distinguishes between different levels of recursion.
+var_dump(Teds\strict_hash($values));
+echo "Test deeper recursion level\n";
+$values[0][0] = &$values;
+
+var_dump(Teds\strict_hash($values));
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  *RECURSION*
+}
+int(1357152471)
+int(944359473)
+array(1) {
+  [0]=>
+  *RECURSION*
+}
+int(1357152471)
+int(944359473)
+Recursive arrays hashed in a predictable way
+array(2) {
+  [0]=>
+  &array(2) {
+    [0]=>
+    *RECURSION*
+    [1]=>
+    int(123)
+  }
+  [1]=>
+  &array(2) {
+    [0]=>
+    *RECURSION*
+    [1]=>
+    int(123)
+  }
+}
+int(-2005905482)
+int(-2005905482)
+Test deeper recursion level
+int(-2086164413)

--- a/tests/misc/strict_hash_array_references_32bit.phpt
+++ b/tests/misc/strict_hash_array_references_32bit.phpt
@@ -1,0 +1,73 @@
+--TEST--
+Test strict_hash() function on array references
+--SKIPIF--
+<?php if (PHP_INT_SIZE >= 8) echo "skip 32-bit only\n"; ?>
+--FILE--
+<?php
+
+function dump_hash($value) {
+    var_dump($value);
+    printf("=>%016x\n", Teds\strict_hash($value));
+}
+$arr = [1, 2];
+dump_hash($arr);
+$a = &$arr[0];
+dump_hash($arr);  // same hash
+dump_hash([1 => 2, 0 => 1]); // different hash for different key order
+function create_array(int $i) {
+    return [$i];
+}
+$arr = [create_array(0), create_array(0)];
+dump_hash($arr);
+$arr[0] = &$arr[1];
+dump_hash($arr);
+
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+}
+=>00000000a6b43259
+array(2) {
+  [0]=>
+  &int(1)
+  [1]=>
+  int(2)
+}
+=>00000000a6b43259
+array(2) {
+  [1]=>
+  int(2)
+  [0]=>
+  int(1)
+}
+=>000000006343e9c9
+array(2) {
+  [0]=>
+  array(1) {
+    [0]=>
+    int(0)
+  }
+  [1]=>
+  array(1) {
+    [0]=>
+    int(0)
+  }
+}
+=>0000000070108f71
+array(2) {
+  [0]=>
+  &array(1) {
+    [0]=>
+    int(0)
+  }
+  [1]=>
+  &array(1) {
+    [0]=>
+    int(0)
+  }
+}
+=>0000000070108f71

--- a/tests/misc/strict_hash_recursion_32bit.phpt
+++ b/tests/misc/strict_hash_recursion_32bit.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test strict_hash() function edge cases
+--SKIPIF--
+<?php if (PHP_INT_SIZE >= 8) echo "skip 32-bit only\n"; ?>
+--FILE--
+<?php
+
+class Dumper {
+    public function __debugInfo() {
+        return ['hash(a)' => Teds\strict_hash($GLOBALS['a'])];
+    }
+}
+$a = [new Dumper()];
+echo "hash(a)=" . Teds\strict_hash($a), "\n";
+var_dump($a);
+echo "hash(a)=" . Teds\strict_hash($a), "\n";
+?>
+--EXPECT--
+hash(a)=180824612
+array(1) {
+  [0]=>
+  object(Dumper)#1 (1) {
+    ["hash(a)"]=>
+    int(180824612)
+  }
+}
+hash(a)=180824612


### PR DESCRIPTION
Change serialization format of LowMemoryVector to be consistent with
BitVector. Fix bugs serializing+unserializing output of LowMemoryVector.

Closes #58