### PR TITLE
Change StrictTreeSet removal to shift iterators backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Much more efficient in memory usage and random access than SplDoublyLinkedList.
 
 (Also similar to `Ds\Deque`)
 
-### Teds\StrictTreeMap
+### Teds\StrictTreeMap and Teds\StrictTreeSet
 
 [`Teds\StrictTreeMap` API](./teds_stricthashmap.stub.php)
 
@@ -202,7 +202,7 @@ This is a map where entries for keys of any type can be inserted if `Teds\stable
 
 This currently uses a balanced [red-black tree](https://en.wikipedia.org/wiki/Red%E2%80%93black_tree) to ensure logarithmic time is needed for insertions/removals/lookups.
 
-Iteration will stop if the current key of an iterator is removed.
+Removing a `Teds\StrictTreeMap`/`Teds\StrictTreeSet` entry will move iterators pointing to that entries to the entry before the removed entry (as of 1.2.1).
 
 This uses [`Teds\stable_compare`](#stable-comparison) internally.
 
@@ -212,15 +212,15 @@ The [`Teds\StrictTreeSet` API](./teds_stricttreeset.stub.php) implementation is 
 
 [`Teds\StrictHashMap` API](./teds_stricthashmap.stub.php)
 
-**This is a work in progress.** Iteration will not work as expected if the hash table is rehashed due to insertions/removals during iteration.
-
 This is a map where entries for keys of any type can be inserted if they are `!==` to other keys.
 This uses [`Teds\strict_hash`](#strict-hashing) internally.
 
 The [`Teds\StrictHashSet` API](./teds_stricthashset.stub.php) implementation is similar, but does not associate values with keys and does not implement ArrayAccess and uses different method names.
 
 NOTE: The floats `0.0` and [`-0.0` (negative zero)](https://en.wikipedia.org/wiki/Signed_zero) have the same hashes and are treated as the same entries, because `0.0 === -0.0` in php.
-NOTE: The float `NAN` (Not a Number) is deliberately treated as equivalent to itself by `Teds\strict_hash` and  `StrictHashSet`/`StrictHashMap`, despite having `NAN !== $x` in php for any $x, including NAN. This is done to avoid duplicate or unremovable entries.
+NOTE: The float `NAN` (Not a Number) is deliberately treated as equivalent to itself by `Teds\strict_hash` and  `StrictHashSet`/`StrictHashMap`, despite having `NAN !== $x` in php for any $x, including `NAN`. This is done to avoid duplicate or unremovable entries.
+
+**Iteration on hash maps/sets is a work in progress.** Iteration will not work as expected if the hash table is rehashed due to insertions/removals during iteration.
 
 ### Teds\StrictMinHeap and Teds\StrictMaxHeap
 

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,9 @@
  <notes>
 * Update documentation
 * Make iteration of Teds\StrictSortedVectorSet and Teds\StrictSortedVectorMap account for removals and additions.
+* Make removal in Teds\StrictTreeSet and Teds\StrictTreeMap move iterators to the previous node if the iterator pointed to the removed node.
+  Add a state for iterators being prior to the start of the tree.
+  Use the state of being before the first value of the tree when calling InternalIterator::rewind on an empty tree or removing an iterator pointing to the first value in a tree.
 * Change iteration behavior of Teds\Deque to be like Vector, make shift/pop behave the same way as offsetUnset with respect to iteration.
   (If the iterator is moved to be before the start of the deque, calling next will move it to the front, and other changes to the Deque will have no effect)
  </notes>

--- a/teds_stricttreemap.h
+++ b/teds_stricttreemap.h
@@ -26,15 +26,15 @@ typedef struct _teds_stricttreemap_node {
 	struct _teds_stricttreemap_node *parent;
 } teds_stricttreemap_node;
 
-#define TEDS_STRICTTREEMAP_NODE_REFCOUNT(node) Z_EXTRA((node)->key)
 #define TEDS_STRICTTREEMAP_NODE_COLOR(node) Z_EXTRA((node)->value)
 #define TEDS_STRICTTREEMAP_NODE_COLOR_NULLABLE(node) ((node) != NULL ? TEDS_STRICTTREEMAP_NODE_COLOR(node) : TEDS_NODE_BLACK)
 
 typedef struct _teds_stricttreemap_tree {
 	struct _teds_stricttreemap_node *root;
-	uint32_t nNumOfElements;
-	bool should_rebuild_properties;
-	bool initialized;
+	teds_intrusive_dllist            active_iterators;
+	uint32_t                         nNumOfElements;
+	bool                             should_rebuild_properties;
+	bool                             initialized;
 } teds_stricttreemap_tree;
 
 typedef struct _teds_stricttreemap {

--- a/teds_stricttreeset.h
+++ b/teds_stricttreeset.h
@@ -12,6 +12,8 @@
 
 PHP_MINIT_FUNCTION(teds_stricttreeset);
 
+#include "teds_internaliterator.h"
+
 typedef struct _teds_stricttreeset_node {
 	zval key;
 	union {
@@ -22,16 +24,15 @@ typedef struct _teds_stricttreeset_node {
 		struct _teds_stricttreeset_node *children[2];
 	};
 	struct _teds_stricttreeset_node *parent;
-	uint8_t color;
 } teds_stricttreeset_node;
 
 /* TODO move color into high bit of Z_EXTRA and benchmark? */
-#define TEDS_STRICTTREESET_NODE_REFCOUNT(node) Z_EXTRA((node)->key)
-#define TEDS_STRICTTREESET_NODE_COLOR(node) ((node)->color)
+#define TEDS_STRICTTREESET_NODE_COLOR(node) Z_EXTRA((node)->key)
 #define TEDS_STRICTTREESET_NODE_COLOR_NULLABLE(node) ((node) != NULL ? TEDS_STRICTTREESET_NODE_COLOR(node) : TEDS_NODE_BLACK)
 
 typedef struct _teds_stricttreeset_tree {
 	struct _teds_stricttreeset_node *root;
+	teds_intrusive_dllist active_iterators;
 	uint32_t nNumOfElements;
 	bool initialized;
 	bool should_rebuild_properties;

--- a/tests/Map/iteration.phpt
+++ b/tests/Map/iteration.phpt
@@ -43,5 +43,9 @@ count=4
 [["k_20","k_200"],["k_30",false],["k_25","k_123"],["k_35",{}]]
 Test Teds\StrictTreeMap
 key: "k_0", value: {}
-count=2
-[["k_20","k_200"],["k_30",false]]
+key: "k_20", value: "k_200"
+key: "k_25", value: "k_123"
+key: "k_30", value: false
+key: "k_35", value: {}
+count=4
+[["k_20","k_200"],["k_25","k_123"],["k_30",false],["k_35",{}]]

--- a/tests/Set/iteration.phpt
+++ b/tests/Set/iteration.phpt
@@ -40,4 +40,8 @@ string(4) "k_35"
 ["k_20","k_30","k_25","k_35"]
 Test Teds\StrictTreeSet
 string(3) "k_0"
-["k_20","k_30"]
+string(4) "k_20"
+string(4) "k_25"
+string(4) "k_30"
+string(4) "k_35"
+["k_20","k_25","k_30","k_35"]

--- a/tests/StrictTreeMap/iteration_delete.phpt
+++ b/tests/StrictTreeMap/iteration_delete.phpt
@@ -14,6 +14,14 @@ $it->rewind();
 var_dump($map);
 echo "After rewind\n";
 echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+echo "After add\n";
+for ($i = 0; $i < 3; $i++) {
+    $map["k$i"] = "v$i";
+}
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+echo "After another rewind\n";
+$it->rewind();
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
 foreach ($it as $key => $value) {
     unset($map[$key]);
     printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
@@ -25,22 +33,24 @@ var_dump($map);
 --EXPECT--
 Key: 'first'
 Value: 'x'
-{"valid":false,"key":null,"current":null}
-object(Teds\StrictTreeMap)#1 (1) {
-  [0]=>
-  array(2) {
-    [0]=>
-    string(6) "second"
-    [1]=>
-    object(stdClass)#2 (0) {
-    }
-  }
-}
-After rewind
-{"valid":true,"key":"second","current":{}}
 Key: 'second'
 Value: (object) array(
 )
+{"valid":false,"key":null,"current":null}
+object(Teds\StrictTreeMap)#1 (0) {
+}
+After rewind
+{"valid":false,"key":null,"current":null}
+After add
+{"valid":false,"key":null,"current":null}
+After another rewind
+{"valid":true,"key":"k0","current":"v0"}
+Key: 'k0'
+Value: 'v0'
+Key: 'k1'
+Value: 'v1'
+Key: 'k2'
+Value: 'v2'
 {"valid":false,"key":null,"current":null}
 object(Teds\StrictTreeMap)#1 (0) {
 }

--- a/tests/StrictTreeSet/iteration_delete.phpt
+++ b/tests/StrictTreeSet/iteration_delete.phpt
@@ -14,6 +14,15 @@ $it->rewind();
 var_dump($set);
 echo "After rewind\n";
 echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+echo "After add\n";
+for ($i = 0; $i < 3; $i++) {
+    $set->add("k$i");
+}
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+echo "After rewind again\n";
+$it->rewind();
+echo json_encode(['valid' => $it->valid(), 'key' => $it->key(), 'current' => $it->current()]), "\n";
+
 foreach ($it as $key => $value) {
     var_dump($set->remove($value));
     printf("Key: %s\nValue: %s\n", var_export($key, true), var_export($value, true));
@@ -25,19 +34,27 @@ var_dump($set);
 --EXPECT--
 bool(true)
 Value: 'x'
-{"valid":false,"key":null,"current":null}
-object(Teds\StrictTreeSet)#1 (1) {
-  [0]=>
-  object(stdClass)#2 (0) {
-  }
-}
-After rewind
-{"valid":true,"key":{},"current":{}}
 bool(true)
-Key: (object) array(
-)
 Value: (object) array(
 )
+{"valid":false,"key":null,"current":null}
+object(Teds\StrictTreeSet)#1 (0) {
+}
+After rewind
+{"valid":false,"key":null,"current":null}
+After add
+{"valid":false,"key":null,"current":null}
+After rewind again
+{"valid":true,"key":"k0","current":"k0"}
+bool(true)
+Key: 'k0'
+Value: 'k0'
+bool(true)
+Key: 'k1'
+Value: 'k1'
+bool(true)
+Key: 'k2'
+Value: 'k2'
 {"valid":false,"key":null,"current":null}
 object(Teds\StrictTreeSet)#1 (0) {
 }


### PR DESCRIPTION
Add a state for iterators being before the start of the tree.