### PR TITLE
Release 1.2.3 - change pop(), fix reference handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ tests/*/*.php
 tests/*/*.exp
 tests/*/*.log
 tests/*/*.sh
+*.result

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,8 @@
  <date>2022-03-06</date>
  <time>16:00:00</time>
  <version>
-  <release>1.2.2</release>
-  <api>1.2.2</api>
+  <release>1.2.3</release>
+  <api>1.2.3</api>
  </version>
  <stability>
   <release>stable</release>
@@ -22,10 +22,10 @@
  </stability>
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* Fix bugs in Teds\StrictHashSet/Teds\StrictHashMap iteration behavior.
-* Fix bug constructing balanced tree in Teds\StrictTreeSet/Teds\StrictTreeMap from array/unserializing, where certain sizes resulted in trees not maintaining the balancing invariant.
-* Fix bug when constructing Teds\IntVector from array when promoting type but not keeping reserved capacity.
-* Fix bugs in Teds\StrictSortedVectorSet::__construct
+* Make pop() on Sequences affect iterators the same way that `$o->offsetUnset(count($o) - 1)` would.
+  (Move iterators pointing to the removed entry backwards by 1)
+* Make pop() on MutableIterable move iterators pointing to that entry backwards.
+* Properly convert references to non-references in some Collection constructors/unserializers and `Teds\unique_values()`
  </notes>
  <contents>
   <dir name="/">
@@ -165,6 +165,7 @@
     <file name="CachedIterable/unserialize.phpt" role="test" />
     <file name="Collection/aggregate.phpt" role="test" />
     <file name="Collection/clear_nonempty.phpt" role="test" />
+    <file name="Collection/create_references.phpt" role="test" />
     <file name="Collection/empty.phpt" role="test" />
     <file name="Collection/exceptionhandler.phpt" role="test" />
     <file name="Collection/fromArray.phpt" role="test" />
@@ -271,10 +272,12 @@
     <file name="Sequence/insert.phpt" role="test" />
     <file name="Sequence/insert_foreach.phpt" role="test" />
     <file name="Sequence/insert_iteration.phpt" role="test" />
+    <file name="Sequence/pop_iteration.phpt" role="test" />
     <file name="Sequence/set.phpt" role="test" />
     <file name="Sequence/set_state.phpt" role="test" />
     <file name="Sequence/shift.phpt" role="test" />
     <file name="Set/contains.phpt" role="test" />
+    <file name="Set/deduplicate.phpt" role="test" />
     <file name="Set/floatKey.phpt" role="test" />
     <file name="Set/gc.phpt" role="test" />
     <file name="Set/iteration.phpt" role="test" />
@@ -367,6 +370,7 @@
     <file name="iterable/none_array.phpt" role="test" />
     <file name="iterable/none_traversable.phpt" role="test" />
     <file name="iterable/unique_values.phpt" role="test" />
+    <file name="iterable/unique_values_references.phpt" role="test" />
     <file name="iterable/unique_values_traversable.phpt" role="test" />
     <file name="misc/binary_search.phpt" role="test" />
     <file name="misc/binary_search_edge_case.phpt" role="test" />
@@ -401,6 +405,25 @@
  <providesextension>teds</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2022-03-06</date>
+   <time>16:00:00</time>
+   <version>
+    <release>1.2.2</release>
+    <api>1.2.2</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
+   <notes>
+* Fix bugs in Teds\StrictHashSet/Teds\StrictHashMap iteration behavior.
+* Fix bug constructing balanced tree in Teds\StrictTreeSet/Teds\StrictTreeMap from array/unserializing, where certain sizes resulted in trees not maintaining the balancing invariant.
+* Fix bug when constructing Teds\IntVector from array when promoting type but not keeping reserved capacity.
+* Fix bugs in Teds\StrictSortedVectorSet::__construct
+   </notes>
+  </release>
   <release>
    <date>2022-03-05</date>
    <time>16:00:00</time>

--- a/php_teds.h
+++ b/php_teds.h
@@ -27,7 +27,7 @@ struct _teds_intrusive_dllist;
 
 PHP_MINIT_FUNCTION(teds);
 
-# define PHP_TEDS_VERSION "1.2.2"
+# define PHP_TEDS_VERSION "1.2.3"
 
 # if defined(ZTS) && defined(COMPILE_DL_TEDS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/teds.c
+++ b/teds.c
@@ -442,16 +442,41 @@ static inline zend_array* teds_move_zend_array_from_entries(teds_stricthashset_e
 	return result;
 }
 
+static zend_always_inline bool teds_is_list_of_non_references(HashTable *ht) {
+	zend_long n;
+	zend_string *str;
+	zval *val;
+	zend_long i = 0;
+	ZEND_HASH_FOREACH_KEY_VAL(ht, n, str, val) {
+		if (n != i || str != NULL || Z_TYPE_P(val) == IS_REFERENCE) {
+			return false;
+		}
+		i++;
+	} ZEND_HASH_FOREACH_END();
+	return true;
+}
+
 static inline void teds_array_unique_values(HashTable *ht, zval *return_value)
 {
-	if (zend_hash_num_elements(ht) <= 1) {
-		if (zend_hash_num_elements(ht) == 0) {
+	const uint32_t ht_size = zend_hash_num_elements(ht);
+	if (ht_size <= 1) {
+		if (ht_size == 0) {
 			RETURN_EMPTY_ARRAY();
 		}
-		HashTable *result = zend_new_array(1);
 		HashPosition start = 0;
 		zval *value = zend_hash_get_current_data_ex(ht, &start);
 		ZEND_ASSERT(value != NULL);
+		if (UNEXPECTED(Z_TYPE_P(value) == IS_REFERENCE)) {
+			ZVAL_DEREF(value);
+		} else {
+			zend_string *str_index;
+			zend_long num_index;
+			if (zend_hash_get_current_key_ex(ht, &str_index, &num_index, &start) == HASH_KEY_IS_LONG && num_index == 0) {
+				GC_TRY_ADDREF(ht);
+				RETURN_ARR(ht);
+			}
+		}
+		HashTable *result = zend_new_array(1);
 		Z_TRY_ADDREF_P(value);
 		zend_hash_next_index_insert(result, value);
 		RETURN_ARR(result);
@@ -461,7 +486,13 @@ static inline void teds_array_unique_values(HashTable *ht, zval *return_value)
 	if (UNEXPECTED(EG(exception))) {
 		RETURN_THROWS();
 	}
-	RETVAL_ARR(teds_move_zend_array_from_entries(&array));
+	ZEND_ASSERT(array.nNumOfElements <= ht_size);
+	if (ht_size == array.nNumOfElements && teds_is_list_of_non_references(ht)) {
+		GC_TRY_ADDREF(ht);
+		teds_stricthashset_entries_dtor(&array);
+		RETURN_ARR(ht);
+	}
+	RETURN_ARR(teds_move_zend_array_from_entries(&array));
 }
 
 static inline void teds_traversable_unique_values(zend_object *obj, zval *return_value)

--- a/teds.h
+++ b/teds.h
@@ -206,4 +206,7 @@ static zend_always_inline uint32_t teds_strict_hash_uint32_t(zval *value) {
 zend_long teds_stable_compare(const zval *v1, const zval *v2);
 int teds_stable_compare_wrap(const void *v1, const void *v2);
 
+/* Check that the zval is not undefined and not a reference/indirect */
+#define TEDS_ASSERT_ZVAL_IS_VALUE_TYPE(v) ZEND_ASSERT(Z_TYPE_P((v)) >= IS_NULL && Z_TYPE_P((v)) <= IS_RESOURCE)
+
 #endif	/* TEDS_H */

--- a/teds_deque.c
+++ b/teds_deque.c
@@ -1310,7 +1310,10 @@ PHP_METHOD(Teds_Deque, pop)
 		RETURN_THROWS();
 	}
 
+	teds_deque_maybe_adjust_iterators_before_remove(array, old_size - 1);
+
 	zval *val = teds_deque_get_entry_at_offset(array, old_size - 1);
+
 	array->size--;
 	array->should_rebuild_properties = true;
 	/* This is being removed. Use a macro that doesn't change the total reference count. */

--- a/teds_intvector.c
+++ b/teds_intvector.c
@@ -2243,6 +2243,7 @@ PHP_METHOD(Teds_IntVector, pop)
 		zend_throw_exception(spl_ce_UnderflowException, "Cannot pop from empty Teds\\IntVector", 0);
 		RETURN_THROWS();
 	}
+	teds_intvector_maybe_adjust_iterators_before_remove(array, old_size - 1);
 	const size_t old_capacity = array->capacity;
 	array->size--;
 	teds_intvector_entries_copy_offset(array, array->size, return_value, true);

--- a/teds_lowmemoryvector.c
+++ b/teds_lowmemoryvector.c
@@ -293,6 +293,7 @@ static void teds_lowmemoryvector_entries_init_from_traversable(teds_lowmemoryvec
 		if (UNEXPECTED(EG(exception))) {
 			break;
 		}
+		ZVAL_DEREF(value);
 
 		teds_lowmemoryvector_entries_push(array, value, true);
 
@@ -1079,6 +1080,7 @@ static void teds_lowmemoryvector_entries_init_from_array_values(teds_lowmemoryve
 	/* TODO: Can probably precompute capacity to avoid reallocations in common case where type tag doesn't change */
 	zval *val;
 	ZEND_HASH_FOREACH_VAL(raw_data, val) {
+		ZVAL_DEREF(val);
 		teds_lowmemoryvector_entries_push(array, val, true);
 	} ZEND_HASH_FOREACH_END();
 }
@@ -1716,7 +1718,6 @@ static zend_never_inline void teds_lowmemoryvector_entries_promote_int64_to_zval
 
 static zend_always_inline void teds_lowmemoryvector_entries_update_type_tag(teds_lowmemoryvector_entries *array, const zval *val)
 {
-
 	ZEND_ASSERT(Z_TYPE_P(val) >= IS_NULL && Z_TYPE_P(val) <= IS_RESOURCE);
 	switch (array->type_tag) {
 		case LMV_TYPE_UNINITIALIZED:
@@ -1917,6 +1918,7 @@ PHP_METHOD(Teds_LowMemoryVector, pop)
 		zend_throw_exception(spl_ce_UnderflowException, "Cannot pop from empty Teds\\LowMemoryVector", 0);
 		RETURN_THROWS();
 	}
+	teds_lowmemoryvector_maybe_adjust_iterators_before_remove(array, old_size - 1);
 	const size_t old_capacity = array->capacity;
 	array->size--;
 	teds_lowmemoryvector_entries_copy_offset(array, array->size, return_value, false, true);

--- a/teds_stricthashset.c
+++ b/teds_stricthashset.c
@@ -97,6 +97,7 @@ static zend_always_inline bool teds_stricthashset_entries_insert(teds_stricthash
 {
 	teds_stricthashset_entry *p;
 	ZEND_ASSERT(Z_TYPE_P(key) != IS_UNDEF);
+	ZEND_ASSERT(Z_TYPE_P(key) != IS_REFERENCE);
 
 	const uint32_t h = teds_strict_hash_uint32_t(key);
 
@@ -207,6 +208,7 @@ void teds_stricthashset_entries_init_from_array(teds_stricthashset_entries *arra
 		teds_stricthashset_entries_set_capacity(array, TEDS_STRICTHASHSET_MIN_CAPACITY);
 		/* NOTE: Unlike StrictHashMap's init_from_array, where keys are unique, this is creating a StrictHashSet from the values of the array */
 		ZEND_HASH_FOREACH_VAL(values, val)  {
+			ZVAL_DEREF(val);
 			teds_stricthashset_entries_insert(array, val, false);
 		} ZEND_HASH_FOREACH_END();
 	} else {

--- a/teds_strictheap.c
+++ b/teds_strictheap.c
@@ -69,6 +69,7 @@ static zend_always_inline bool teds_strictheap_should_be_above(zval *a, zval *b,
 
 static zend_always_inline void teds_strictheap_entries_insert(teds_strictheap_entries *array, zval *key, const bool is_min_heap) {
 	/* Reallocate if needed and sift down. */
+	ZEND_ASSERT(Z_TYPE_P(key) >= IS_NULL && Z_TYPE_P(key) <= IS_RESOURCE);
 	uint32_t offset = array->size;
 	if (offset >= array->capacity) {
 		/* FIXME bounds check */
@@ -127,6 +128,7 @@ static void teds_strictheap_entries_init_from_array(teds_strictheap_entries *arr
 		array->entries = teds_strictheap_allocate_entries(capacity);
 		array->capacity = size;
 		ZEND_HASH_FOREACH_VAL(values, val)  {
+			ZVAL_DEREF(val);
 			teds_strictheap_entries_insert(array, val, is_min_heap);
 		} ZEND_HASH_FOREACH_END();
 	} else {
@@ -377,6 +379,7 @@ PHP_METHOD(Teds_StrictMinHeap, __unserialize)
 			RETURN_THROWS();
 		}
 
+		ZVAL_DEREF(val);
 		teds_strictheap_entries_insert(array, val, true);
 	} ZEND_HASH_FOREACH_END();
 }
@@ -421,6 +424,7 @@ PHP_METHOD(Teds_StrictMaxHeap, __unserialize)
 			RETURN_THROWS();
 		}
 
+		ZVAL_DEREF(val);
 		teds_strictheap_entries_insert(array, val, false);
 	} ZEND_HASH_FOREACH_END();
 }

--- a/teds_strictsortedvectorset.c
+++ b/teds_strictsortedvectorset.c
@@ -57,6 +57,7 @@ static teds_strictsortedvectorset_search_result teds_strictsortedvectorset_entri
 static teds_strictsortedvectorset_search_result teds_strictsortedvectorset_entries_sorted_search_for_key_probably_largest(const teds_strictsortedvectorset_entries *array, zval *key);
 
 static bool teds_strictsortedvectorset_entries_insert(teds_strictsortedvectorset_entries *array, zval *key, bool probably_largest) {
+	ZEND_ASSERT(Z_TYPE_P(key) >= IS_NULL && Z_TYPE_P(key) <= IS_RESOURCE);
 	teds_strictsortedvectorset_search_result result = probably_largest
 		? teds_strictsortedvectorset_entries_sorted_search_for_key_probably_largest(array, key)
 		: teds_strictsortedvectorset_entries_sorted_search_for_key(array, key);
@@ -500,6 +501,7 @@ PHP_METHOD(Teds_StrictSortedVectorSet, __unserialize)
 			RETURN_THROWS();
 		}
 
+		ZVAL_DEREF(val);
 		teds_strictsortedvectorset_entries_insert(array, val, true);
 	} ZEND_HASH_FOREACH_END();
 }

--- a/teds_vector.c
+++ b/teds_vector.c
@@ -1293,6 +1293,9 @@ PHP_METHOD(Teds_Vector, pop)
 		zend_throw_exception_ex(spl_ce_UnderflowException, 0, "Cannot pop from empty %s", ZSTR_VAL(intern->std.ce->name));
 		RETURN_THROWS();
 	}
+
+	teds_vector_maybe_adjust_iterators_before_remove(array, old_size - 1);
+
 	const uint32_t old_capacity = array->capacity;
 	array->size--;
 	array->should_rebuild_properties = true;

--- a/tests/Collection/create_references.phpt
+++ b/tests/Collection/create_references.phpt
@@ -1,0 +1,887 @@
+--TEST--
+Teds\Collections create from array with references
+--FILE--
+<?php
+
+function test_nonempty_implementation(string $class_name) {
+    echo "Testing $class_name\n";
+    try {
+        $s = "v_$class_name";
+        $collection = new $class_name([&$s, &$s]);
+        var_dump($collection);
+        printf("count=%d\n", count($collection));
+        var_dump($collection);
+        echo "values: ";
+        var_dump($collection->values());
+    } catch (Throwable $e) {
+        echo "ERROR: Failed to test non-empty $class_name : {$e->getMessage()}\n";
+    }
+    echo "Testing $class_name from Traversable\n";
+    try {
+        $s = "v_$class_name";
+        $ao = new ArrayObject([&$s, &$s]);
+
+        $collection = new $class_name($ao);
+        var_dump($collection);
+        printf("count=%d\n", count($collection));
+        var_dump($collection);
+        echo "values: ";
+        var_dump($collection->values());
+    } catch (Throwable $e) {
+        echo "ERROR: Failed to test non-empty $class_name : {$e->getMessage()}\n";
+    }
+
+    echo "\n";
+}
+
+foreach ([
+    // Teds\BitVector::class,
+    Teds\Deque::class,
+    Teds\ImmutableIterable::class,
+    Teds\ImmutableSequence::class,
+    Teds\ImmutableSortedStringSet::class,
+    // Teds\IntVector::class,
+    Teds\LowMemoryVector::class,
+    Teds\MutableIterable::class,
+    Teds\StrictHashMap::class,
+    Teds\StrictHashSet::class,
+    Teds\StrictMaxHeap::class,
+    Teds\StrictMinHeap::class,
+    Teds\StrictSortedVectorMap::class,
+    Teds\StrictSortedVectorSet::class,
+    Teds\StrictTreeMap::class,
+    Teds\StrictTreeSet::class,
+    Teds\Vector::class,
+    Teds\CachedIterable::class,
+] as $class_name) {
+    test_nonempty_implementation($class_name);
+}
+?>
+--EXPECTF--
+Testing Teds\Deque
+object(Teds\Deque)#%d (2) {
+  [0]=>
+  string(12) "v_Teds\Deque"
+  [1]=>
+  string(12) "v_Teds\Deque"
+}
+count=2
+object(Teds\Deque)#%d (2) {
+  [0]=>
+  string(12) "v_Teds\Deque"
+  [1]=>
+  string(12) "v_Teds\Deque"
+}
+values: array(2) {
+  [0]=>
+  string(12) "v_Teds\Deque"
+  [1]=>
+  string(12) "v_Teds\Deque"
+}
+Testing Teds\Deque from Traversable
+object(Teds\Deque)#%d (2) {
+  [0]=>
+  string(12) "v_Teds\Deque"
+  [1]=>
+  string(12) "v_Teds\Deque"
+}
+count=2
+object(Teds\Deque)#%d (2) {
+  [0]=>
+  string(12) "v_Teds\Deque"
+  [1]=>
+  string(12) "v_Teds\Deque"
+}
+values: array(2) {
+  [0]=>
+  string(12) "v_Teds\Deque"
+  [1]=>
+  string(12) "v_Teds\Deque"
+}
+
+Testing Teds\ImmutableIterable
+object(Teds\ImmutableIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(24) "v_Teds\ImmutableIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(24) "v_Teds\ImmutableIterable"
+  }
+}
+count=2
+object(Teds\ImmutableIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(24) "v_Teds\ImmutableIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(24) "v_Teds\ImmutableIterable"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(24) "v_Teds\ImmutableIterable"
+  [1]=>
+  string(24) "v_Teds\ImmutableIterable"
+}
+Testing Teds\ImmutableIterable from Traversable
+object(Teds\ImmutableIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(24) "v_Teds\ImmutableIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(24) "v_Teds\ImmutableIterable"
+  }
+}
+count=2
+object(Teds\ImmutableIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(24) "v_Teds\ImmutableIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(24) "v_Teds\ImmutableIterable"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(24) "v_Teds\ImmutableIterable"
+  [1]=>
+  string(24) "v_Teds\ImmutableIterable"
+}
+
+Testing Teds\ImmutableSequence
+object(Teds\ImmutableSequence)#%d (2) {
+  [0]=>
+  string(24) "v_Teds\ImmutableSequence"
+  [1]=>
+  string(24) "v_Teds\ImmutableSequence"
+}
+count=2
+object(Teds\ImmutableSequence)#%d (2) {
+  [0]=>
+  string(24) "v_Teds\ImmutableSequence"
+  [1]=>
+  string(24) "v_Teds\ImmutableSequence"
+}
+values: array(2) {
+  [0]=>
+  string(24) "v_Teds\ImmutableSequence"
+  [1]=>
+  string(24) "v_Teds\ImmutableSequence"
+}
+Testing Teds\ImmutableSequence from Traversable
+object(Teds\ImmutableSequence)#%d (2) {
+  [0]=>
+  string(24) "v_Teds\ImmutableSequence"
+  [1]=>
+  string(24) "v_Teds\ImmutableSequence"
+}
+count=2
+object(Teds\ImmutableSequence)#%d (2) {
+  [0]=>
+  string(24) "v_Teds\ImmutableSequence"
+  [1]=>
+  string(24) "v_Teds\ImmutableSequence"
+}
+values: array(2) {
+  [0]=>
+  string(24) "v_Teds\ImmutableSequence"
+  [1]=>
+  string(24) "v_Teds\ImmutableSequence"
+}
+
+Testing Teds\ImmutableSortedStringSet
+object(Teds\ImmutableSortedStringSet)#%d (1) {
+  [0]=>
+  string(31) "v_Teds\ImmutableSortedStringSet"
+}
+count=1
+object(Teds\ImmutableSortedStringSet)#%d (1) {
+  [0]=>
+  string(31) "v_Teds\ImmutableSortedStringSet"
+}
+values: array(1) {
+  [0]=>
+  string(31) "v_Teds\ImmutableSortedStringSet"
+}
+Testing Teds\ImmutableSortedStringSet from Traversable
+object(Teds\ImmutableSortedStringSet)#%d (1) {
+  [0]=>
+  string(31) "v_Teds\ImmutableSortedStringSet"
+}
+count=1
+object(Teds\ImmutableSortedStringSet)#%d (1) {
+  [0]=>
+  string(31) "v_Teds\ImmutableSortedStringSet"
+}
+values: array(1) {
+  [0]=>
+  string(31) "v_Teds\ImmutableSortedStringSet"
+}
+
+Testing Teds\LowMemoryVector
+object(Teds\LowMemoryVector)#%d (0) {
+}
+count=2
+object(Teds\LowMemoryVector)#%d (0) {
+}
+values: array(2) {
+  [0]=>
+  string(22) "v_Teds\LowMemoryVector"
+  [1]=>
+  string(22) "v_Teds\LowMemoryVector"
+}
+Testing Teds\LowMemoryVector from Traversable
+object(Teds\LowMemoryVector)#%d (0) {
+}
+count=2
+object(Teds\LowMemoryVector)#%d (0) {
+}
+values: array(2) {
+  [0]=>
+  string(22) "v_Teds\LowMemoryVector"
+  [1]=>
+  string(22) "v_Teds\LowMemoryVector"
+}
+
+Testing Teds\MutableIterable
+object(Teds\MutableIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(22) "v_Teds\MutableIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(22) "v_Teds\MutableIterable"
+  }
+}
+count=2
+object(Teds\MutableIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(22) "v_Teds\MutableIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(22) "v_Teds\MutableIterable"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(22) "v_Teds\MutableIterable"
+  [1]=>
+  string(22) "v_Teds\MutableIterable"
+}
+Testing Teds\MutableIterable from Traversable
+object(Teds\MutableIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(22) "v_Teds\MutableIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(22) "v_Teds\MutableIterable"
+  }
+}
+count=2
+object(Teds\MutableIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(22) "v_Teds\MutableIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(22) "v_Teds\MutableIterable"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(22) "v_Teds\MutableIterable"
+  [1]=>
+  string(22) "v_Teds\MutableIterable"
+}
+
+Testing Teds\StrictHashMap
+object(Teds\StrictHashMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(20) "v_Teds\StrictHashMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(20) "v_Teds\StrictHashMap"
+  }
+}
+count=2
+object(Teds\StrictHashMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(20) "v_Teds\StrictHashMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(20) "v_Teds\StrictHashMap"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(20) "v_Teds\StrictHashMap"
+  [1]=>
+  string(20) "v_Teds\StrictHashMap"
+}
+Testing Teds\StrictHashMap from Traversable
+object(Teds\StrictHashMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(20) "v_Teds\StrictHashMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(20) "v_Teds\StrictHashMap"
+  }
+}
+count=2
+object(Teds\StrictHashMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(20) "v_Teds\StrictHashMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(20) "v_Teds\StrictHashMap"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(20) "v_Teds\StrictHashMap"
+  [1]=>
+  string(20) "v_Teds\StrictHashMap"
+}
+
+Testing Teds\StrictHashSet
+object(Teds\StrictHashSet)#%d (1) {
+  [0]=>
+  string(20) "v_Teds\StrictHashSet"
+}
+count=1
+object(Teds\StrictHashSet)#%d (1) {
+  [0]=>
+  string(20) "v_Teds\StrictHashSet"
+}
+values: array(1) {
+  [0]=>
+  string(20) "v_Teds\StrictHashSet"
+}
+Testing Teds\StrictHashSet from Traversable
+object(Teds\StrictHashSet)#%d (1) {
+  [0]=>
+  string(20) "v_Teds\StrictHashSet"
+}
+count=1
+object(Teds\StrictHashSet)#%d (1) {
+  [0]=>
+  string(20) "v_Teds\StrictHashSet"
+}
+values: array(1) {
+  [0]=>
+  string(20) "v_Teds\StrictHashSet"
+}
+
+Testing Teds\StrictMaxHeap
+object(Teds\StrictMaxHeap)#%d (2) {
+  [0]=>
+  string(20) "v_Teds\StrictMaxHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMaxHeap"
+}
+count=2
+object(Teds\StrictMaxHeap)#%d (2) {
+  [0]=>
+  string(20) "v_Teds\StrictMaxHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMaxHeap"
+}
+values: array(2) {
+  [0]=>
+  string(20) "v_Teds\StrictMaxHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMaxHeap"
+}
+Testing Teds\StrictMaxHeap from Traversable
+object(Teds\StrictMaxHeap)#%d (2) {
+  [0]=>
+  string(20) "v_Teds\StrictMaxHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMaxHeap"
+}
+count=2
+object(Teds\StrictMaxHeap)#%d (2) {
+  [0]=>
+  string(20) "v_Teds\StrictMaxHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMaxHeap"
+}
+values: array(2) {
+  [0]=>
+  string(20) "v_Teds\StrictMaxHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMaxHeap"
+}
+
+Testing Teds\StrictMinHeap
+object(Teds\StrictMinHeap)#%d (2) {
+  [0]=>
+  string(20) "v_Teds\StrictMinHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMinHeap"
+}
+count=2
+object(Teds\StrictMinHeap)#%d (2) {
+  [0]=>
+  string(20) "v_Teds\StrictMinHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMinHeap"
+}
+values: array(2) {
+  [0]=>
+  string(20) "v_Teds\StrictMinHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMinHeap"
+}
+Testing Teds\StrictMinHeap from Traversable
+object(Teds\StrictMinHeap)#%d (2) {
+  [0]=>
+  string(20) "v_Teds\StrictMinHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMinHeap"
+}
+count=2
+object(Teds\StrictMinHeap)#%d (2) {
+  [0]=>
+  string(20) "v_Teds\StrictMinHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMinHeap"
+}
+values: array(2) {
+  [0]=>
+  string(20) "v_Teds\StrictMinHeap"
+  [1]=>
+  string(20) "v_Teds\StrictMinHeap"
+}
+
+Testing Teds\StrictSortedVectorMap
+object(Teds\StrictSortedVectorMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(28) "v_Teds\StrictSortedVectorMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(28) "v_Teds\StrictSortedVectorMap"
+  }
+}
+count=2
+object(Teds\StrictSortedVectorMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(28) "v_Teds\StrictSortedVectorMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(28) "v_Teds\StrictSortedVectorMap"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(28) "v_Teds\StrictSortedVectorMap"
+  [1]=>
+  string(28) "v_Teds\StrictSortedVectorMap"
+}
+Testing Teds\StrictSortedVectorMap from Traversable
+object(Teds\StrictSortedVectorMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(28) "v_Teds\StrictSortedVectorMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(28) "v_Teds\StrictSortedVectorMap"
+  }
+}
+count=2
+object(Teds\StrictSortedVectorMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(28) "v_Teds\StrictSortedVectorMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(28) "v_Teds\StrictSortedVectorMap"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(28) "v_Teds\StrictSortedVectorMap"
+  [1]=>
+  string(28) "v_Teds\StrictSortedVectorMap"
+}
+
+Testing Teds\StrictSortedVectorSet
+object(Teds\StrictSortedVectorSet)#%d (1) {
+  [0]=>
+  string(28) "v_Teds\StrictSortedVectorSet"
+}
+count=1
+object(Teds\StrictSortedVectorSet)#%d (1) {
+  [0]=>
+  string(28) "v_Teds\StrictSortedVectorSet"
+}
+values: array(1) {
+  [0]=>
+  string(28) "v_Teds\StrictSortedVectorSet"
+}
+Testing Teds\StrictSortedVectorSet from Traversable
+object(Teds\StrictSortedVectorSet)#%d (0) {
+}
+count=1
+object(Teds\StrictSortedVectorSet)#%d (0) {
+}
+values: array(1) {
+  [0]=>
+  string(28) "v_Teds\StrictSortedVectorSet"
+}
+
+Testing Teds\StrictTreeMap
+object(Teds\StrictTreeMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(20) "v_Teds\StrictTreeMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(20) "v_Teds\StrictTreeMap"
+  }
+}
+count=2
+object(Teds\StrictTreeMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(20) "v_Teds\StrictTreeMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(20) "v_Teds\StrictTreeMap"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(20) "v_Teds\StrictTreeMap"
+  [1]=>
+  string(20) "v_Teds\StrictTreeMap"
+}
+Testing Teds\StrictTreeMap from Traversable
+object(Teds\StrictTreeMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(20) "v_Teds\StrictTreeMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(20) "v_Teds\StrictTreeMap"
+  }
+}
+count=2
+object(Teds\StrictTreeMap)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(20) "v_Teds\StrictTreeMap"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(20) "v_Teds\StrictTreeMap"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(20) "v_Teds\StrictTreeMap"
+  [1]=>
+  string(20) "v_Teds\StrictTreeMap"
+}
+
+Testing Teds\StrictTreeSet
+object(Teds\StrictTreeSet)#%d (1) {
+  [0]=>
+  string(20) "v_Teds\StrictTreeSet"
+}
+count=1
+object(Teds\StrictTreeSet)#%d (1) {
+  [0]=>
+  string(20) "v_Teds\StrictTreeSet"
+}
+values: array(1) {
+  [0]=>
+  string(20) "v_Teds\StrictTreeSet"
+}
+Testing Teds\StrictTreeSet from Traversable
+object(Teds\StrictTreeSet)#%d (1) {
+  [0]=>
+  string(20) "v_Teds\StrictTreeSet"
+}
+count=1
+object(Teds\StrictTreeSet)#%d (1) {
+  [0]=>
+  string(20) "v_Teds\StrictTreeSet"
+}
+values: array(1) {
+  [0]=>
+  string(20) "v_Teds\StrictTreeSet"
+}
+
+Testing Teds\Vector
+object(Teds\Vector)#%d (2) {
+  [0]=>
+  string(13) "v_Teds\Vector"
+  [1]=>
+  string(13) "v_Teds\Vector"
+}
+count=2
+object(Teds\Vector)#%d (2) {
+  [0]=>
+  string(13) "v_Teds\Vector"
+  [1]=>
+  string(13) "v_Teds\Vector"
+}
+values: array(2) {
+  [0]=>
+  string(13) "v_Teds\Vector"
+  [1]=>
+  string(13) "v_Teds\Vector"
+}
+Testing Teds\Vector from Traversable
+object(Teds\Vector)#%d (2) {
+  [0]=>
+  string(13) "v_Teds\Vector"
+  [1]=>
+  string(13) "v_Teds\Vector"
+}
+count=2
+object(Teds\Vector)#%d (2) {
+  [0]=>
+  string(13) "v_Teds\Vector"
+  [1]=>
+  string(13) "v_Teds\Vector"
+}
+values: array(2) {
+  [0]=>
+  string(13) "v_Teds\Vector"
+  [1]=>
+  string(13) "v_Teds\Vector"
+}
+
+Testing Teds\CachedIterable
+object(Teds\CachedIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(21) "v_Teds\CachedIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(21) "v_Teds\CachedIterable"
+  }
+}
+count=2
+object(Teds\CachedIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(21) "v_Teds\CachedIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(21) "v_Teds\CachedIterable"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(21) "v_Teds\CachedIterable"
+  [1]=>
+  string(21) "v_Teds\CachedIterable"
+}
+Testing Teds\CachedIterable from Traversable
+object(Teds\CachedIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(21) "v_Teds\CachedIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(21) "v_Teds\CachedIterable"
+  }
+}
+count=2
+object(Teds\CachedIterable)#%d (2) {
+  [0]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    string(21) "v_Teds\CachedIterable"
+  }
+  [1]=>
+  array(2) {
+    [0]=>
+    int(1)
+    [1]=>
+    string(21) "v_Teds\CachedIterable"
+  }
+}
+values: array(2) {
+  [0]=>
+  string(21) "v_Teds\CachedIterable"
+  [1]=>
+  string(21) "v_Teds\CachedIterable"
+}

--- a/tests/Sequence/pop_iteration.phpt
+++ b/tests/Sequence/pop_iteration.phpt
@@ -1,0 +1,112 @@
+--TEST--
+Teds\Sequence pop() with iterators
+--FILE--
+<?php
+function print_it_state(Iterator $it, string $name) {
+    if (!$it->valid()) {
+        printf("%s valid=false\n", $name);
+    } else {
+        printf("%s valid=true key=%s value=%s\n", $name, json_encode($it->key()), json_encode($it->current()));
+    }
+}
+foreach ([
+    Teds\Deque::class,
+    Teds\Vector::class,
+    Teds\LowMemoryVector::class,
+    Teds\IntVector::class,
+    Teds\BitVector::class,
+] as $class_name) {
+    echo "Test $class_name\n";
+    if ($class_name !== Teds\BitVector::class) {
+        $sequence = new $class_name([1000]);
+    } else {
+        $sequence = new $class_name([true]);
+    }
+    $it1 = $sequence->getIterator();
+    $it2 = $sequence->getIterator();
+    $it2->next();
+    print_it_state($it1, 'it1');
+    print_it_state($it2, 'it2');
+    $v = $sequence->pop();
+    echo "Popped: ";
+    var_dump($v);
+    print_it_state($it1, 'it1');
+    print_it_state($it2, 'it2');
+    echo "After push\n";
+    $sequence->push($v);
+    print_it_state($it1, 'it1');
+    print_it_state($it2, 'it2');
+    $it1->next();
+    print_it_state($it1, 'it1 after next()');
+    echo "After push again\n";
+    $sequence->push(is_int($v) ? $v * 2 : !$v);
+    print_it_state($it1, 'it1');
+    print_it_state($it2, 'it2');
+}
+?>
+--EXPECT--
+Test Teds\Deque
+it1 valid=true key=0 value=1000
+it2 valid=false
+Popped: int(1000)
+it1 valid=false
+it2 valid=false
+After push
+it1 valid=false
+it2 valid=false
+it1 after next() valid=true key=0 value=1000
+After push again
+it1 valid=true key=0 value=1000
+it2 valid=true key=1 value=2000
+Test Teds\Vector
+it1 valid=true key=0 value=1000
+it2 valid=false
+Popped: int(1000)
+it1 valid=false
+it2 valid=false
+After push
+it1 valid=false
+it2 valid=false
+it1 after next() valid=true key=0 value=1000
+After push again
+it1 valid=true key=0 value=1000
+it2 valid=true key=1 value=2000
+Test Teds\LowMemoryVector
+it1 valid=true key=0 value=1000
+it2 valid=false
+Popped: int(1000)
+it1 valid=false
+it2 valid=false
+After push
+it1 valid=false
+it2 valid=false
+it1 after next() valid=true key=0 value=1000
+After push again
+it1 valid=true key=0 value=1000
+it2 valid=true key=1 value=2000
+Test Teds\IntVector
+it1 valid=true key=0 value=1000
+it2 valid=false
+Popped: int(1000)
+it1 valid=false
+it2 valid=false
+After push
+it1 valid=false
+it2 valid=false
+it1 after next() valid=true key=0 value=1000
+After push again
+it1 valid=true key=0 value=1000
+it2 valid=true key=1 value=2000
+Test Teds\BitVector
+it1 valid=true key=0 value=true
+it2 valid=false
+Popped: bool(true)
+it1 valid=false
+it2 valid=false
+After push
+it1 valid=false
+it2 valid=false
+it1 after next() valid=true key=0 value=true
+After push again
+it1 valid=true key=0 value=true
+it2 valid=true key=1 value=false

--- a/tests/Set/deduplicate.phpt
+++ b/tests/Set/deduplicate.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Teds\Set deduplicate
+--FILE--
+<?php
+foreach ([Teds\StrictHashSet::class, Teds\StrictTreeSet::class, Teds\StrictSortedVectorSet::class] as $class_name) {
+    echo "Test $class_name\n";
+    $values = [];
+    $set = new $class_name([1, 3, 5, 3, 3, 2, 1, 8]);
+    printf("count=%d values=%s\n", count($set), json_encode($set->values()));
+}
+?>
+--EXPECT--
+Test Teds\StrictHashSet
+count=5 values=[1,3,5,2,8]
+Test Teds\StrictTreeSet
+count=5 values=[1,2,3,5,8]
+Test Teds\StrictSortedVectorSet
+count=5 values=[1,2,3,5,8]

--- a/tests/iterable/unique_values_references.phpt
+++ b/tests/iterable/unique_values_references.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Test unique_values() function on arrays with/without references
+--FILE--
+<?php
+
+use function Teds\unique_values;
+
+function dump_unique_values(iterable $input) {
+    echo "For " . json_encode($input) . ": ";
+    var_dump(unique_values($input));
+}
+/* Create a reference counted key */
+$create_key = function (int $x): string {
+    return "k$x";
+};
+dump_unique_values([]);
+$x = $create_key(1);
+$y = $create_key(2);
+dump_unique_values([true]);
+$orig = [&$x];
+dump_unique_values($orig);
+var_dump($orig);
+$orig = [&$x, &$x];
+dump_unique_values($orig);
+var_dump($orig);
+
+dump_unique_values([$x, &$y, $y, &$x]);
+$original = [NAN];
+dump_unique_values($original);
+echo "Returns original array: ";
+var_dump(Teds\is_same_array_handle($original, Teds\unique_values($original)));
+?>
+--EXPECT--
+For []: array(0) {
+}
+For [true]: array(1) {
+  [0]=>
+  bool(true)
+}
+For ["k1"]: array(1) {
+  [0]=>
+  string(2) "k1"
+}
+array(1) {
+  [0]=>
+  &string(2) "k1"
+}
+For ["k1","k1"]: array(1) {
+  [0]=>
+  string(2) "k1"
+}
+array(2) {
+  [0]=>
+  &string(2) "k1"
+  [1]=>
+  &string(2) "k1"
+}
+For ["k1","k2","k2","k1"]: array(2) {
+  [0]=>
+  string(2) "k1"
+  [1]=>
+  string(2) "k2"
+}
+For : array(1) {
+  [0]=>
+  float(NAN)
+}
+Returns original array: bool(true)


### PR DESCRIPTION
Make pop() affect iterators like offsetUnset

Iterators pointing to the element/entry removed with pop() will be moved
backwards, consistently.

Convert references to non-references when constructing/unserializing from
arrays/traversables in a few Collections that missed that step