### PR TITLE
1.2.4: Fix test failures in php 8.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 # Based on php-ast's appveyor config.
 # See https://github.com/nikic/php-ast/blob/master/.appveyor.yml
-# This tests against the multiple minor versions of PHP 7
+# This tests against multiple minor versions of PHP 7 and 8
 # Author: Tyson Andre
 
 version: '{branch}.{build}'
@@ -36,22 +36,32 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.1.1
+                  PHP_VER: 8.2.0beta2
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.1.1
+                  PHP_VER: 8.2.0beta2
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x86
                   VC: vs16
-                  PHP_VER: 8.0.14
+                  PHP_VER: 8.1.9
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
                   ARCH: x64
                   VC: vs16
-                  PHP_VER: 8.0.14
+                  PHP_VER: 8.1.9
+                  TS: 0
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x86
+                  VC: vs16
+                  PHP_VER: 8.0.22
+                  TS: 1
+                - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+                  ARCH: x64
+                  VC: vs16
+                  PHP_VER: 8.0.22
                   TS: 0
 
 build_script:

--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-03-06</date>
+ <date>2022-08-14</date>
  <time>16:00:00</time>
  <version>
-  <release>1.2.3</release>
-  <api>1.2.3</api>
+  <release>1.2.4</release>
+  <api>1.2.4</api>
  </version>
  <stability>
   <release>stable</release>
@@ -22,10 +22,7 @@
  </stability>
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* Make pop() on Sequences affect iterators the same way that `$o->offsetUnset(count($o) - 1)` would.
-  (Move iterators pointing to the removed entry backwards by 1)
-* Make pop() on MutableIterable move iterators pointing to that entry backwards.
-* Properly convert references to non-references in some Collection constructors/unserializers and `Teds\unique_values()`
+* Fix test failures/deprecation notices seen in PHP 8.2.
  </notes>
  <contents>
   <dir name="/">
@@ -405,6 +402,25 @@
  <providesextension>teds</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2022-03-06</date>
+   <time>16:00:00</time>
+   <version>
+    <release>1.2.3</release>
+    <api>1.2.3</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
+   <notes>
+* Make pop() on Sequences affect iterators the same way that `$o->offsetUnset(count($o) - 1)` would.
+  (Move iterators pointing to the removed entry backwards by 1)
+* Make pop() on MutableIterable move iterators pointing to that entry backwards.
+* Properly convert references to non-references in some Collection constructors/unserializers and `Teds\unique_values()`
+   </notes>
+  </release>
   <release>
    <date>2022-03-06</date>
    <time>16:00:00</time>

--- a/php_teds.h
+++ b/php_teds.h
@@ -11,11 +11,13 @@
 # define PHP_TEDS_H
 
 #include "teds_internaliterator.h"
+#include "zend_long.h"
 
 #if SIZEOF_ZEND_LONG > SIZEOF_SIZE_T
 // See php-src/Zend/zend_range_check.h
 // > Furthermore, by the current design, size_t can always
 // > overflow zend_long.
+// This error can happen when compiling php with a 32-bit compiler configuration but compiling the extension with a 64-bit compiler configuration.
 #error Expected SIZEOF_ZEND_LONG <= SIZEOF_SIZE_T to be guaranteed by php-src.
 #endif
 
@@ -27,7 +29,7 @@ struct _teds_intrusive_dllist;
 
 PHP_MINIT_FUNCTION(teds);
 
-# define PHP_TEDS_VERSION "1.2.3"
+# define PHP_TEDS_VERSION "1.2.4"
 
 # if defined(ZTS) && defined(COMPILE_DL_TEDS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/teds.c
+++ b/teds.c
@@ -442,6 +442,7 @@ static inline zend_array* teds_move_zend_array_from_entries(teds_stricthashset_e
 	return result;
 }
 
+/* Check if this is the hash table of a PHP array satisfying array_is_list() where none of the top level array values are references. */
 static zend_always_inline bool teds_is_list_of_non_references(HashTable *ht) {
 	zend_long n;
 	zend_string *str;
@@ -472,6 +473,7 @@ static inline void teds_array_unique_values(HashTable *ht, zval *return_value)
 			zend_string *str_index;
 			zend_long num_index;
 			if (zend_hash_get_current_key_ex(ht, &str_index, &num_index, &start) == HASH_KEY_IS_LONG && num_index == 0) {
+				/* The input array is already a single-element list of non-references of size 1 */
 				GC_TRY_ADDREF(ht);
 				RETURN_ARR(ht);
 			}
@@ -488,6 +490,7 @@ static inline void teds_array_unique_values(HashTable *ht, zval *return_value)
 	}
 	ZEND_ASSERT(array.nNumOfElements <= ht_size);
 	if (ht_size == array.nNumOfElements && teds_is_list_of_non_references(ht)) {
+		/* Save memory by returning the original list when it's safe to do so. */
 		GC_TRY_ADDREF(ht);
 		teds_stricthashset_entries_dtor(&array);
 		RETURN_ARR(ht);


### PR DESCRIPTION
And start testing in AppVeyor with php 8.2