### PR TITLE
1.2.5: Fix and optimize get_properties/get_properties_for handlers

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-08-14</date>
+ <date>2022-10-10</date>
  <time>16:00:00</time>
  <version>
-  <release>1.2.4</release>
-  <api>1.2.4</api>
+  <release>1.2.5</release>
+  <api>1.2.5</api>
  </version>
  <stability>
   <release>stable</release>
@@ -22,7 +22,9 @@
  </stability>
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* Fix test failures/deprecation notices seen in PHP 8.2.
+* Reduce memory usage by refactoring the way properties/fields of data structures are returned, for var_export/var_dump/debug_zval_dump/array type casts/serialize.
+  In php 8.3+, this should reduce the impact of calling var_export/var_dump/debug_zval_dump on memory usage, and avoid the side effect of keeping around references to fields after those calls..
+  In all php versions, consistently return temporary arrays for remaining data structures in serialize() and array type casts that will be freed after being used.
  </notes>
  <contents>
   <dir name="/">
@@ -402,6 +404,22 @@
  <providesextension>teds</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2022-08-14</date>
+   <time>16:00:00</time>
+   <version>
+    <release>1.2.4</release>
+    <api>1.2.4</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
+   <notes>
+* Fix test failures/deprecation notices seen in PHP 8.2.
+   </notes>
+  </release>
   <release>
    <date>2022-03-06</date>
    <time>16:00:00</time>

--- a/php_teds.h
+++ b/php_teds.h
@@ -29,7 +29,7 @@ struct _teds_intrusive_dllist;
 
 PHP_MINIT_FUNCTION(teds);
 
-# define PHP_TEDS_VERSION "1.2.4"
+# define PHP_TEDS_VERSION "1.2.5"
 
 # if defined(ZTS) && defined(COMPILE_DL_TEDS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/teds_bitvector.c
+++ b/teds_bitvector.c
@@ -287,7 +287,7 @@ static HashTable* teds_bitvector_get_properties_for(zend_object *obj, zend_prop_
 	}
 	/* var_export uses get_properties_for for infinite recursion detection rather than get_properties(Z_OBJPROP).
 	 * or checking for recursion on the object itself (php_var_dump).
-	 * However, BitVector can only contain integers, making infinite recursion impossible, so it's safe to return new arrays. */
+	 * However, BitVector can only contain booleans, making infinite recursion impossible, so it's safe to return new arrays. */
 	return teds_bitvector_entries_to_refcounted_array(array);
 }
 
@@ -1665,7 +1665,6 @@ PHP_MINIT_FUNCTION(teds_bitvector)
 	teds_handler_BitVector.offset          = XtOffsetOf(teds_bitvector, std);
 	teds_handler_BitVector.clone_obj       = teds_bitvector_clone;
 	teds_handler_BitVector.count_elements  = teds_bitvector_count_elements;
-	teds_handler_BitVector.get_properties  = teds_noop_empty_array_get_properties;
 	teds_handler_BitVector.get_properties_for = teds_bitvector_get_properties_for;
 	teds_handler_BitVector.get_gc          = teds_noop_get_gc;
 	teds_handler_BitVector.free_obj        = teds_bitvector_free_storage;

--- a/teds_emptycollection.c
+++ b/teds_emptycollection.c
@@ -415,12 +415,12 @@ static void teds_handlers_empty_enum_init_common(zend_object_handlers *handlers)
 {
 	// Based on static function zend_register_enum_ce
 	memcpy(handlers, &std_object_handlers, sizeof(zend_object_handlers));
-	handlers->clone_obj       = NULL;
-	handlers->offset          = 0;
-	handlers->compare         = zend_objects_not_comparable;
-	handlers->count_elements  = teds_emptysequence_count_elements;
-	handlers->get_properties  = teds_noop_empty_array_get_properties;
-	handlers->get_gc          = teds_noop_get_gc;
+	handlers->clone_obj          = NULL;
+	handlers->offset             = 0;
+	handlers->compare            = zend_objects_not_comparable;
+	handlers->count_elements     = teds_emptysequence_count_elements;
+	handlers->get_properties_for = teds_noop_empty_array_get_properties_for;
+	handlers->get_gc             = teds_noop_get_gc;
 }
 
 PHP_MINIT_FUNCTION(teds_emptycollection)

--- a/teds_immutableiterable.c
+++ b/teds_immutableiterable.c
@@ -279,6 +279,7 @@ static HashTable* teds_immutableiterable_get_gc(zend_object *obj, zval **table, 
 	return NULL;
 }
 
+#if PHP_VERSION_ID < 80300
 void teds_build_properties_for_immutable_zval_pairs(HashTable *ht, zval_pair *entries, const uint32_t len)
 {
 	ZEND_ASSERT(len <= TEDS_MAX_ZVAL_PAIR_COUNT);
@@ -298,23 +299,45 @@ void teds_build_properties_for_immutable_zval_pairs(HashTable *ht, zval_pair *en
 	}
 #endif
 }
+#endif
 
-static HashTable* teds_immutableiterable_get_properties(zend_object *obj)
+static HashTable* teds_immutableiterable_get_properties_for(zend_object *obj, zend_prop_purpose purpose)
 {
-	teds_immutableiterable *intern = teds_immutableiterable_from_object(obj);
-	const uint32_t len = intern->array.size;
+	teds_immutableiterable_entries *array = &teds_immutableiterable_from_object(obj)->array;
+
+	const uint32_t len = array->size;
 	if (!len) {
 		/* Nothing to add or remove - this is immutable. */
 		/* debug_zval_dump DEBUG purpose requires null or a refcounted array. */
 		return NULL;
 	}
-	HashTable *ht = zend_std_get_properties(obj);
-	if (zend_hash_num_elements(ht)) {
-		/* Already built. This is immutable there is no need to rebuild it. */
-		return ht;
+	switch (purpose) {
+		case ZEND_PROP_PURPOSE_JSON: /* jsonSerialize and get_properties() is used instead. */
+			ZEND_UNREACHABLE();
+		case ZEND_PROP_PURPOSE_VAR_EXPORT:
+		case ZEND_PROP_PURPOSE_DEBUG:
+#if PHP_VERSION_ID < 80300
+		/* In php 8.3, var_export and debug_zval_dump now check for infinite recursion on the object */
+		{
+			HashTable *ht = zend_std_get_properties(obj);
+			if (zend_hash_num_elements(ht)) {
+				GC_TRY_ADDREF(ht);
+				/* Already built. This is immutable there is no need to rebuild it. */
+				return ht;
+			}
+			teds_build_properties_for_immutable_zval_pairs(ht, array->entries, len);
+			/* When modifying the hash table, the reference count should be 1. Increase refcount after modifying. */
+			GC_TRY_ADDREF(ht);
+			return ht;
+		}
+#endif
+		case ZEND_PROP_PURPOSE_ARRAY_CAST:
+		case ZEND_PROP_PURPOSE_SERIALIZE:
+			return teds_zval_pairs_to_refcounted_pairs(array->entries, len);
+		default:
+			ZEND_UNREACHABLE();
+			return NULL;
 	}
-	teds_build_properties_for_immutable_zval_pairs(ht, intern->array.entries, len);
-	return ht;
 }
 
 static void teds_immutableiterable_free_storage(zend_object *object)
@@ -923,6 +946,26 @@ PHP_METHOD(Teds_ImmutableIterable, contains)
 	RETURN_FALSE;
 }
 
+zend_array *teds_zval_pairs_to_refcounted_pairs(zval_pair *entries, uint32_t len)
+{
+	zend_array *values = zend_new_array(len);
+	/* Initialize return array */
+	zend_hash_real_init_packed(values);
+
+	/* Go through values and add values to the return array */
+	ZEND_HASH_FILL_PACKED(values) {
+		for (uint32_t i = 0; i < len; i++) {
+			zval tmp;
+			Z_TRY_ADDREF_P(&entries[i].key);
+			Z_TRY_ADDREF_P(&entries[i].value);
+			ZVAL_ARR(&tmp, zend_new_pair(&entries[i].key, &entries[i].value));
+			ZEND_HASH_FILL_ADD(&tmp);
+		}
+	} ZEND_HASH_FILL_END();
+	return values;
+}
+
+
 static void teds_immutableiterable_return_pairs(zval *return_value, teds_immutableiterable *intern)
 {
 	const uint32_t len = intern->array.size;
@@ -990,7 +1033,7 @@ PHP_MINIT_FUNCTION(teds_immutableiterable)
 	teds_handler_ImmutableIterable.offset          = XtOffsetOf(teds_immutableiterable, std);
 	teds_handler_ImmutableIterable.clone_obj       = teds_immutableiterable_clone;
 	teds_handler_ImmutableIterable.count_elements  = teds_immutableiterable_count_elements;
-	teds_handler_ImmutableIterable.get_properties  = teds_immutableiterable_get_properties;
+	teds_handler_ImmutableIterable.get_properties_for = teds_immutableiterable_get_properties_for;
 	teds_handler_ImmutableIterable.get_gc          = teds_immutableiterable_get_gc;
 	teds_handler_ImmutableIterable.dtor_obj        = zend_objects_destroy_object;
 	teds_handler_ImmutableIterable.free_obj        = teds_immutableiterable_free_storage;

--- a/teds_immutableiterable.h
+++ b/teds_immutableiterable.h
@@ -17,5 +17,6 @@ extern zend_class_entry *teds_ce_ImmutableIterable;
 PHP_MINIT_FUNCTION(teds_immutableiterable);
 
 void teds_build_properties_for_immutable_zval_pairs(HashTable *ht, zval_pair *entries, const uint32_t len);
+zend_array *teds_zval_pairs_to_refcounted_pairs(zval_pair *entries, uint32_t len);
 
 #endif	/* TEDS_IMMUTABLEITERABLE_H */

--- a/teds_immutablesortedstringset.c
+++ b/teds_immutablesortedstringset.c
@@ -938,7 +938,6 @@ PHP_MINIT_FUNCTION(teds_immutablesortedstringset)
 	teds_handler_ImmutableSortedStringSet.offset          = XtOffsetOf(teds_immutablesortedstringset, std);
 	teds_handler_ImmutableSortedStringSet.clone_obj       = teds_immutablesortedstringset_clone;
 	teds_handler_ImmutableSortedStringSet.count_elements  = teds_immutablesortedstringset_count_elements;
-	teds_handler_ImmutableSortedStringSet.get_properties  = teds_noop_empty_array_get_properties;
 	teds_handler_ImmutableSortedStringSet.get_properties_for = teds_immutablesortedstringset_get_properties_for;
 	teds_handler_ImmutableSortedStringSet.get_gc          = teds_noop_get_gc;
 	teds_handler_ImmutableSortedStringSet.free_obj        = teds_immutablesortedstringset_free_storage;

--- a/teds_intvector.c
+++ b/teds_intvector.c
@@ -2431,7 +2431,6 @@ PHP_MINIT_FUNCTION(teds_intvector)
 	teds_handler_IntVector.offset          = XtOffsetOf(teds_intvector, std);
 	teds_handler_IntVector.clone_obj       = teds_intvector_clone;
 	teds_handler_IntVector.count_elements  = teds_intvector_count_elements;
-	teds_handler_IntVector.get_properties  = teds_noop_empty_array_get_properties;
 	teds_handler_IntVector.get_properties_for = teds_intvector_get_properties_for;
 	teds_handler_IntVector.get_gc          = teds_intvector_get_gc;
 	teds_handler_IntVector.free_obj        = teds_intvector_free_storage;
@@ -2451,7 +2450,6 @@ PHP_MINIT_FUNCTION(teds_intvector)
 	teds_handler_SortedIntVectorSet.offset          = XtOffsetOf(teds_intvector, std);
 	teds_handler_SortedIntVectorSet.clone_obj       = teds_sortedintvectorset_clone;
 	teds_handler_SortedIntVectorSet.count_elements  = teds_intvector_count_elements;
-	teds_handler_SortedIntVectorSet.get_properties  = teds_noop_empty_array_get_properties;
 	teds_handler_SortedIntVectorSet.get_properties_for = teds_intvector_get_properties_for;
 	teds_handler_SortedIntVectorSet.get_gc          = teds_intvector_get_gc;
 	teds_handler_SortedIntVectorSet.free_obj        = teds_intvector_free_storage;
@@ -2468,7 +2466,6 @@ PHP_MINIT_FUNCTION(teds_intvector)
 	teds_handler_ImmutableSortedIntSet.offset          = XtOffsetOf(teds_intvector, std);
 	// teds_handler_ImmutableSortedIntSet.clone_obj       = teds_immutablesortedintset_clone;
 	teds_handler_ImmutableSortedIntSet.count_elements  = teds_intvector_count_elements;
-	teds_handler_ImmutableSortedIntSet.get_properties  = teds_noop_empty_array_get_properties;
 	teds_handler_ImmutableSortedIntSet.get_properties_for = teds_intvector_get_properties_for;
 	teds_handler_ImmutableSortedIntSet.get_gc          = teds_intvector_get_gc;
 	teds_handler_ImmutableSortedIntSet.free_obj        = teds_immutablesortedintset_free_storage;

--- a/teds_mutableiterable.h
+++ b/teds_mutableiterable.h
@@ -30,7 +30,7 @@ typedef struct _teds_mutableiterable {
 } teds_mutableiterable;
 
 HashTable* teds_mutableiterable_get_gc(zend_object *obj, zval **table, int *n);
-HashTable* teds_mutableiterable_get_properties(zend_object *obj);
+HashTable* teds_mutableiterable_get_properties_for(zend_object *obj, zend_prop_purpose purpose);
 int teds_mutableiterable_count_elements(zend_object *object, zend_long *count);
 void teds_mutableiterable_free_storage(zend_object *object);
 void teds_mutableiterable_clear(teds_mutableiterable *intern);

--- a/teds_stricthashmap.h
+++ b/teds_stricthashmap.h
@@ -94,7 +94,9 @@ typedef struct _teds_stricthashmap_entries {
 	uint32_t nNumUsed; /* Number of buckets used, including gaps left by remove. */
 	uint32_t nTableMask; /* -nTableSize or TEDS_STRICTHASHMAP_MIN_MASK, e.g. 0xfffffff0 for an array of size 8 with 16 buckets. */
 	uint32_t nFirstUsed; /* The offset of the first bucket used. */
+#if PHP_VERSION_ID < 80300
 	bool should_rebuild_properties;
+#endif
 } teds_stricthashmap_entries;
 
 typedef struct _teds_stricthashmap {

--- a/teds_stricthashset.h
+++ b/teds_stricthashset.h
@@ -96,7 +96,9 @@ typedef struct _teds_stricthashset_entries {
 	uint32_t nTableMask; /* -nTableSize or TEDS_STRICTHASHSET_MIN_MASK, e.g. 0xfffffff0 for an array of size 8 with 16 buckets. */
 	uint32_t nFirstUsed; /* The offset of the first bucket used. */
 	/* TODO could track uint32_t firstUsed for cases where removal of first is common, e.g. LRU caches */
+#if PHP_VERSION_ID < 80300
 	bool should_rebuild_properties;
+#endif
 } teds_stricthashset_entries;
 
 typedef struct _teds_stricthashset {

--- a/teds_strictheap.c
+++ b/teds_strictheap.c
@@ -89,7 +89,7 @@ static zend_always_inline void teds_strictheap_entries_insert(teds_strictheap_en
 	}
 	ZVAL_COPY(&entries[offset], key);
 	array->size++;
-	array->should_rebuild_properties = true;
+	TEDS_SET_SHOULD_REBUILD_PROPERTIES(array, true);
 	ZEND_ASSERT(offset < array->size);
 }
 
@@ -463,10 +463,9 @@ static zend_always_inline void teds_strictheap_entries_remove_top(teds_stricthea
 	zval *const entries = array->entries;
 	ZEND_ASSERT(array->size > 0);
 	const uint32_t len = --array->size;
-	array->should_rebuild_properties = true;
+	TEDS_SET_SHOULD_REBUILD_PROPERTIES(array, true);
 	zval *replacement = &entries[len];
 	uint32_t offset = 0;
-
 
 	/*    0
 	 *  1   2

--- a/teds_strictsortedvectorset.c
+++ b/teds_strictsortedvectorset.c
@@ -85,7 +85,7 @@ static bool teds_strictsortedvectorset_entries_insert(teds_strictsortedvectorset
 
 	ZVAL_COPY(entry, key);
 	array->size++;
-	array->should_rebuild_properties = true;
+	TEDS_SET_SHOULD_REBUILD_PROPERTIES(array, true);
 	return true;
 }
 
@@ -201,7 +201,7 @@ static void teds_strictsortedvectorset_entries_init_from_array(teds_strictsorted
 		ZEND_ASSERT(i == size);
 		array->size = size;
 		array->capacity = size;
-		array->should_rebuild_properties = true;
+		TEDS_SET_SHOULD_REBUILD_PROPERTIES(array, true);
 
 		if (size > 1) {
 			teds_strictsortedvectorset_entries_sort_and_deduplicate(array);
@@ -271,6 +271,7 @@ static void teds_strictsortedvectorset_entries_init_from_traversable(teds_strict
 	array->size = size;
 	array->capacity = capacity;
 	array->entries = entries;
+	TEDS_SET_SHOULD_REBUILD_PROPERTIES(array, size > 0);
 	if (size > 1) {
 		teds_strictsortedvectorset_entries_sort_and_deduplicate(array);
 	}
@@ -313,7 +314,7 @@ static void teds_strictsortedvectorset_entries_copy_ctor(teds_strictsortedvector
 	to->entries = safe_emalloc(capacity, sizeof(zval), 0);
 	to->size = size;
 	to->capacity = capacity;
-	to->should_rebuild_properties = true;
+	TEDS_SET_SHOULD_REBUILD_PROPERTIES(to, true);
 
 	zval *begin = from->entries, *end = from->entries + size;
 	teds_strictsortedvectorset_copy_range(to, 0, begin, end);
@@ -631,7 +632,7 @@ static bool teds_strictsortedvectorset_entries_remove_key(teds_strictsortedvecto
 	ZEND_ASSERT(entry <= end);
 	memmove(entry, entry + 1, (end - entry) * sizeof(zval));
 	array->size--;
-	array->should_rebuild_properties = true;
+	TEDS_SET_SHOULD_REBUILD_PROPERTIES(array, true);
 
 	zval_ptr_dtor(&old_key);
 	return true;

--- a/teds_stricttreemap.h
+++ b/teds_stricttreemap.h
@@ -33,7 +33,9 @@ typedef struct _teds_stricttreemap_tree {
 	struct _teds_stricttreemap_node *root;
 	teds_intrusive_dllist            active_iterators;
 	uint32_t                         nNumOfElements;
+#if PHP_VERSION_ID < 80300
 	bool                             should_rebuild_properties;
+#endif
 	bool                             initialized;
 } teds_stricttreemap_tree;
 

--- a/teds_stricttreeset.h
+++ b/teds_stricttreeset.h
@@ -35,7 +35,9 @@ typedef struct _teds_stricttreeset_tree {
 	teds_intrusive_dllist active_iterators;
 	uint32_t nNumOfElements;
 	bool initialized;
+#if PHP_VERSION_ID < 80300
 	bool should_rebuild_properties;
+#endif
 } teds_stricttreeset_tree;
 
 typedef struct _teds_stricttreeset {

--- a/teds_util.c
+++ b/teds_util.c
@@ -1,9 +1,9 @@
 #include "teds_util.h"
 
-HashTable* teds_noop_empty_array_get_properties(zend_object *obj) {
+/* Override get_properties_for and use the default implementation of get_properties. See https://github.com/php/php-src/issues/9697#issuecomment-1273613175 */
+HashTable* teds_noop_empty_array_get_properties_for(zend_object *obj, zend_prop_purpose purpose) {
 	(void)obj;
-	/* Thankfully, anything using Z_OBJPROP_P for infinite recursion detection (var_export) won't need to worry about infinite recursion, all fields are integers and there are no properties. */
-	/* debug_zval_dump DEBUG purpose requires null or a refcounted array. */
+	(void)purpose;
 	return NULL;
 }
 

--- a/teds_util.h
+++ b/teds_util.h
@@ -4,6 +4,7 @@
 #include "php.h"
 #include "Zend/zend_string.h"
 #include "Zend/zend_types.h"
+#include "Zend/zend_object_handlers.h"
 #define TEDS_NODE_RED 0
 #define TEDS_NODE_BLACK 1
 
@@ -275,7 +276,7 @@ HashTable* teds_noop_get_gc(zend_object *obj, zval **table, int *n);
  * Returns the immutable empty array in a get_properties handler.
  * This is useful to keep memory low when a datastructure is guaranteed to be free of cycles (e.g. only scalars, or empty)
  */
-HashTable* teds_noop_empty_array_get_properties(zend_object *obj);
+HashTable* teds_noop_empty_array_get_properties_for(zend_object *obj, zend_prop_purpose purpose);
 
 HashTable *teds_internaliterator_get_gc(zend_object_iterator *iter, zval **table, int *n);
 

--- a/teds_vector.h
+++ b/teds_vector.h
@@ -21,7 +21,9 @@ typedef struct _teds_vector_entries {
 	uint32_t size;
 	uint32_t capacity;
 	teds_intrusive_dllist active_iterators;
+#if PHP_VERSION_ID < 80300
 	bool should_rebuild_properties;
+#endif
 } teds_vector_entries;
 
 typedef struct _teds_vector {

--- a/tests/Collection/create_references.phpt
+++ b/tests/Collection/create_references.phpt
@@ -644,10 +644,14 @@ values: array(1) {
   string(28) "v_Teds\StrictSortedVectorSet"
 }
 Testing Teds\StrictSortedVectorSet from Traversable
-object(Teds\StrictSortedVectorSet)#%d (0) {
+object(Teds\StrictSortedVectorSet)#%d (1) {
+  [0]=>
+  string(28) "v_Teds\StrictSortedVectorSet"
 }
 count=1
-object(Teds\StrictSortedVectorSet)#%d (0) {
+object(Teds\StrictSortedVectorSet)#%d (1) {
+  [0]=>
+  string(28) "v_Teds\StrictSortedVectorSet"
 }
 values: array(1) {
   [0]=>

--- a/tests/Collection/empty.phpt
+++ b/tests/Collection/empty.phpt
@@ -34,6 +34,14 @@ function test_empty_implementation(string $class_name) {
             }
         }
         var_dump($collection);
+        echo "array_walk: ";
+        var_dump(array_walk($collection, function ($value, $key) { echo "Not called\n"; }));
+        echo "get_mangled_object_vars: ";
+        echo json_encode(get_mangled_object_vars($collection)), "\n";
+        echo "reset: ";
+        ini_set('error_reporting', E_ALL & ~E_DEPRECATED);
+        var_dump(reset($collection)); // reset is deprecated
+        ini_set('error_reporting', E_ALL);
     } catch (Throwable $e) {
         echo "ERROR: Failed to test empty $class_name : {$e->getMessage()}\n";
     }
@@ -77,6 +85,9 @@ first() Caught UnderflowException: Cannot read first bit of empty Teds\BitVector
 last() Caught UnderflowException: Cannot read last bit of empty Teds\BitVector
 object(Teds\BitVector)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\Deque
 values: array(0) {
 }
@@ -89,6 +100,9 @@ first() Caught UnderflowException: Cannot read first value of empty Teds\Deque
 last() Caught UnderflowException: Cannot read last value of empty Teds\Deque
 object(Teds\Deque)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\CachedIterable
 values: array(0) {
 }
@@ -101,6 +115,9 @@ first() Caught Error: Call to undefined method Teds\CachedIterable::first()
 last() Caught Error: Call to undefined method Teds\CachedIterable::last()
 object(Teds\CachedIterable)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\ImmutableIterable
 values: array(0) {
 }
@@ -113,6 +130,9 @@ first() Caught Error: Call to undefined method Teds\ImmutableIterable::first()
 last() Caught Error: Call to undefined method Teds\ImmutableIterable::last()
 object(Teds\ImmutableIterable)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\ImmutableSequence
 values: array(0) {
 }
@@ -125,6 +145,9 @@ first() Caught UnderflowException: Cannot get first element of empty Teds\Immuta
 last() Caught UnderflowException: Cannot get last element of empty Teds\ImmutableSequence
 object(Teds\ImmutableSequence)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\ImmutableSortedIntSet
 values: array(0) {
 }
@@ -137,6 +160,9 @@ first() Caught UnderflowException: Cannot read first value of empty Teds\IntVect
 last() Caught UnderflowException: Cannot read last value of empty Teds\IntVector
 object(Teds\ImmutableSortedIntSet)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\ImmutableSortedStringSet
 values: array(0) {
 }
@@ -149,6 +175,9 @@ first() Caught UnderflowException: Cannot read first value of empty Teds\Immutab
 last() Caught UnderflowException: Cannot read last value of empty Teds\ImmutableSortedStringSet
 object(Teds\ImmutableSortedStringSet)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\IntVector
 values: array(0) {
 }
@@ -161,6 +190,9 @@ first() Caught UnderflowException: Cannot read first value of empty Teds\IntVect
 last() Caught UnderflowException: Cannot read last value of empty Teds\IntVector
 object(Teds\IntVector)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\SortedIntVectorSet
 values: array(0) {
 }
@@ -173,6 +205,9 @@ first() Caught UnderflowException: Cannot read first value of empty Teds\IntVect
 last() Caught UnderflowException: Cannot read last value of empty Teds\IntVector
 object(Teds\SortedIntVectorSet)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\LowMemoryVector
 values: array(0) {
 }
@@ -185,6 +220,9 @@ first() Caught UnderflowException: Cannot read first value of empty Teds\LowMemo
 last() Caught UnderflowException: Cannot read last value of empty Teds\LowMemoryVector
 object(Teds\LowMemoryVector)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\MutableIterable
 values: array(0) {
 }
@@ -197,6 +235,9 @@ first() Caught Error: Call to undefined method Teds\MutableIterable::first()
 last() Caught Error: Call to undefined method Teds\MutableIterable::last()
 object(Teds\MutableIterable)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\StrictHashMap
 values: array(0) {
 }
@@ -209,6 +250,9 @@ first() Caught Error: Call to undefined method Teds\StrictHashMap::first()
 last() Caught Error: Call to undefined method Teds\StrictHashMap::last()
 object(Teds\StrictHashMap)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\StrictHashSet
 values: array(0) {
 }
@@ -221,6 +265,9 @@ first() Caught Error: Call to undefined method Teds\StrictHashSet::first()
 last() Caught Error: Call to undefined method Teds\StrictHashSet::last()
 object(Teds\StrictHashSet)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\StrictMaxHeap
 values: array(0) {
 }
@@ -231,6 +278,9 @@ object(Teds\StrictMaxHeap)#%d (0) refcount(2){
 clear: NULL
 object(Teds\StrictMaxHeap)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\StrictMinHeap
 values: array(0) {
 }
@@ -241,6 +291,9 @@ object(Teds\StrictMinHeap)#%d (0) refcount(2){
 clear: NULL
 object(Teds\StrictMinHeap)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\StrictSortedVectorMap
 values: array(0) {
 }
@@ -253,6 +306,9 @@ first() Caught UnderflowException: Cannot read first of empty Teds\StrictSortedV
 last() Caught UnderflowException: Cannot read last of empty Teds\StrictSortedVectorMap
 object(Teds\StrictSortedVectorMap)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\StrictSortedVectorSet
 values: array(0) {
 }
@@ -265,6 +321,9 @@ first() Caught UnderflowException: Cannot read first value of empty Teds\StrictS
 last() Caught UnderflowException: Cannot read last value of empty Teds\StrictSortedVectorSet
 object(Teds\StrictSortedVectorSet)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\StrictTreeMap
 values: array(0) {
 }
@@ -277,6 +336,9 @@ first() Caught UnderflowException: Cannot read first of empty StrictTreeMap
 last() Caught UnderflowException: Cannot read last of empty StrictTreeMap
 object(Teds\StrictTreeMap)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\StrictTreeSet
 values: array(0) {
 }
@@ -289,6 +351,9 @@ first() Caught UnderflowException: Cannot read first value of empty StrictTreeSe
 last() Caught UnderflowException: Cannot read last value of empty StrictTreeSet
 object(Teds\StrictTreeSet)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)
 Testing Teds\Vector
 values: array(0) {
 }
@@ -301,3 +366,6 @@ first() Caught UnderflowException: Cannot read first value of empty Teds\Vector
 last() Caught UnderflowException: Cannot read last value of empty Teds\Vector
 object(Teds\Vector)#%d (0) {
 }
+array_walk: bool(true)
+get_mangled_object_vars: []
+reset: bool(false)

--- a/tests/Vector/noProps.phpt
+++ b/tests/Vector/noProps.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Teds\Vector get_mangled_object_vars should be empty in php 8.3+
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 80300) echo "skip php 8.3+ only\n"; ?>
+--FILE--
+<?php
+$it = new Teds\Vector([new stdClass()]);
+var_export($it);
+echo "\n", json_encode($it), "\n";
+// The real storage of the data is in the C representation.
+// Redundant representations are deliberately avoided because they'll waste memory.
+// In php 8.2 and older, fields only got added to the properties hash table as a workaround
+// to get both debug output and infinite recursion detection on var_export/debug_zval_dump to work.
+var_dump(get_mangled_object_vars($it));
+?>
+--EXPECTF--
+\Teds\Vector::__set_state(array(
+   0 =>%S
+  (object) array(
+  ),
+))
+[{}]
+array(0) {
+}


### PR DESCRIPTION
Don't keep around properties table longer than they need to be kept in php 8.3+.
Fix crash with array_walk(), reset(), and end() - Don't return null in get_properties.
Switch to get_properties_for.

Combine some redundant functionality