### PR TITLE
Regenerate arginfo. Add Teds\strict_equals()

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <email>tandre@php.net</email>
   <active>yes</active>
  </lead>
- <date>2022-10-27</date>
+ <date>2022-11-10</date>
  <time>16:00:00</time>
  <version>
-  <release>1.2.8</release>
-  <api>1.2.8</api>
+  <release>1.3.0dev</release>
+  <api>1.3.0dev</api>
  </version>
  <stability>
   <release>stable</release>
@@ -22,8 +22,8 @@
  </stability>
  <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
  <notes>
-* Same as 1.2.7 other than the version and tests folder.
-* Update expected test output of the unit test tests/misc/strict_hash_array_recursion_32bit.phpt
+* Regenerate function arginfo with namespaced C symbols from stub.php files.
+* Add Teds\strict_equals($v1, $v2): bool with stricter NAN handling than `===`.
  </notes>
  <contents>
   <dir name="/">
@@ -377,6 +377,7 @@
     <file name="misc/stable_compare.phpt" role="test" />
     <file name="misc/stable_compare_2.phpt" role="test" />
     <file name="misc/stable_compare_3.phpt" role="test" />
+    <file name="misc/strict_equals.phpt" role="test" />
     <file name="misc/strict_hash.phpt" role="test" />
     <file name="misc/strict_hash_32bit.phpt" role="test" />
     <file name="misc/strict_hash_array_recursion.phpt" role="test" />
@@ -406,6 +407,23 @@
  <providesextension>teds</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2022-10-27</date>
+   <time>16:00:00</time>
+   <version>
+    <release>1.2.8</release>
+    <api>1.2.8</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/TysonAndre/teds/blob/main/COPYING">BSD-3-Clause</license>
+   <notes>
+* Same as 1.2.7 other than the version and tests folder.
+* Update expected test output of the unit test tests/misc/strict_hash_array_recursion_32bit.phpt
+   </notes>
+  </release>
   <release>
    <date>2022-10-22</date>
    <time>16:00:00</time>

--- a/php_teds.h
+++ b/php_teds.h
@@ -29,7 +29,7 @@ struct _teds_intrusive_dllist;
 
 PHP_MINIT_FUNCTION(teds);
 
-# define PHP_TEDS_VERSION "1.2.8"
+# define PHP_TEDS_VERSION "1.3.0dev"
 
 # if defined(ZTS) && defined(COMPILE_DL_TEDS)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/teds.c
+++ b/teds.c
@@ -327,28 +327,28 @@ static inline void teds_iterable_until(INTERNAL_FUNCTION_PARAMETERS, int stop_va
 }
 
 /* Determines whether the predicate holds for all elements in the array */
-PHP_FUNCTION(all)
+PHP_FUNCTION(Teds_all)
 {
 	teds_iterable_until(INTERNAL_FUNCTION_PARAM_PASSTHRU, 0, 0);
 }
 /* }}} */
 
 /* {{{ Determines whether the predicate holds for at least one element in the array */
-PHP_FUNCTION(any)
+PHP_FUNCTION(Teds_any)
 {
 	teds_iterable_until(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1, 0);
 }
 /* }}} */
 
 /* {{{ Determines whether the predicate holds for no elements of the array */
-PHP_FUNCTION(none)
+PHP_FUNCTION(Teds_none)
 {
 	teds_iterable_until(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1, 1);
 }
 /* }}} */
 
 /* Determines whether the predicate holds for all elements in the array */
-PHP_FUNCTION(includes_value)
+PHP_FUNCTION(Teds_includes_value)
 {
 	zval *input;
 	zval *value;
@@ -389,7 +389,7 @@ PHP_FUNCTION(includes_value)
 /* }}} */
 
 /* {{{ folds values */
-PHP_FUNCTION(fold)
+PHP_FUNCTION(Teds_fold)
 {
 	zval *input;
 	zend_fcall_info fci;
@@ -512,7 +512,7 @@ static inline void teds_traversable_unique_values(zend_object *obj, zval *return
 }
 
 /* {{{ extracts unique values from an iterable with a hash table */
-PHP_FUNCTION(unique_values)
+PHP_FUNCTION(Teds_unique_values)
 {
 	zval *iterable;
 
@@ -707,7 +707,7 @@ bucket_search_start:
 }
 
 /* Perform a binary search on a sorted array (Assumed to be sorted by value and/or key, depending on $flags) */
-PHP_FUNCTION(binary_search)
+PHP_FUNCTION(Teds_binary_search)
 {
 	HashTable *ht;
 	zend_fcall_info fci = empty_fcall_info;
@@ -859,7 +859,7 @@ static zend_always_inline void teds_traversable_find(zval *obj, zend_fcall_info 
 /* }}} */
 
 /* {{{ Finds the first value or returns the default */
-PHP_FUNCTION(find)
+PHP_FUNCTION(Teds_find)
 {
 	zval *input;
 	zend_fcall_info fci;
@@ -887,7 +887,7 @@ PHP_FUNCTION(find)
 /* }}} */
 
 /* {{{ Get the value of the first element of the array */
-PHP_FUNCTION(array_value_first)
+PHP_FUNCTION(Teds_array_value_first)
 {
 	HashTable *target_hash;
 
@@ -905,7 +905,7 @@ PHP_FUNCTION(array_value_first)
 /* }}} */
 
 /* {{{ Get the value of the last element of the array */
-PHP_FUNCTION(array_value_last)
+PHP_FUNCTION(Teds_array_value_last)
 {
 	HashTable *target_hash;
 	HashPosition pos;
@@ -1037,7 +1037,7 @@ zend_long teds_stable_compare(const zval *v1, const zval *v2) {
 }
 
 /* {{{ Compare two elements in a stable order. */
-PHP_FUNCTION(stable_compare)
+PHP_FUNCTION(Teds_stable_compare)
 {
 	zval *v1;
 	zval *v2;
@@ -1146,7 +1146,7 @@ int teds_hash_zval_identical_or_both_nan_function(zval *op1, zval *op2) {
 }
 
 /* {{{ Compute a strict hash that is the same number if $a === $b */
-PHP_FUNCTION(strict_hash)
+PHP_FUNCTION(Teds_strict_hash)
 {
 	zval *value;
 
@@ -1158,8 +1158,23 @@ PHP_FUNCTION(strict_hash)
 }
 /* }}} */
 
+/* {{{ Compute a strict hash that is the same number if $a === $b */
+PHP_FUNCTION(Teds_strict_equals)
+{
+	zval *v1;
+	zval *v2;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_ZVAL(v1)
+		Z_PARAM_ZVAL(v2)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_BOOL(teds_hash_zval_identical_or_both_nan_function(v1, v2) == 0);
+}
+/* }}} */
+
 /* {{{ Check if two arrays have the same array handle (pointer) */
-PHP_FUNCTION(is_same_array_handle)
+PHP_FUNCTION(Teds_is_same_array_handle)
 {
 	HashTable *array1, *array2;
 

--- a/teds.stub.php
+++ b/teds.stub.php
@@ -1,5 +1,8 @@
 <?php
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 // NOTE: Due to a limitation of gen_stub.php (at)param is used instead
@@ -118,10 +121,27 @@ function stable_compare(mixed $v1, mixed $v2): int { }
  *
  * Future releases of Teds may change the hashing algorithm to improve performance/collision resistance.
  *
- * NOTE: The floats `0.0` and [`-0.0` (negative zero)](https://en.wikipedia.org/wiki/Signed_zero) have the same hashes and are treated as the same entries, because `0.0 === -0.0` in php.
-NOTE: The float `NAN` (Not a Number) is deliberately treated as equivalent to itself by `Teds\strict_hash` and  `StrictHashSet`/`StrictHashMap`, despite having `NAN !== $x` in php for any $x, including NAN. This is done to avoid duplicate or unremovable entries.
+ * NOTE: The floats `0.0` and [`-0.0` (negative zero)](https://en.wikipedia.org/wiki/Signed_zero)
+ * have the same hashes and are treated as the same entries, because `0.0 === -0.0` in php.
+ *
+ * NOTE: The float `NAN` (Not a Number) is deliberately treated as equivalent to itself by `Teds\strict_hash` and  `StrictHashSet`/`StrictHashMap`,
+ * despite having `NAN !== $x` in php for any $x, including NAN.
+ * This is done to avoid duplicate or unremovable entries.
  */
 function strict_hash(mixed $value): int { }
+
+/**
+ * Check if $v1 is equivalent to $v2 the same way that unique_values and StrictHashSet/StrictHashMap would.
+ * Apart from the handling of NAN at any array level, this behaves like PHP's `===`.
+ *
+ * NOTE: The floats `0.0` and [`-0.0` (negative zero)](https://en.wikipedia.org/wiki/Signed_zero)
+ * have the same hashes and are treated as the same entries, because `0.0 === -0.0` in php.
+ *
+ * NOTE: The float `NAN` (Not a Number) is deliberately treated as equivalent to itself by `Teds\strict_equals`,
+ * despite having `NAN !== $x` in php for any $x, including NAN.
+ * This is done to avoid duplicate or unremovable entries in unique_values, hash sets/maps, etc.
+ */
+function strict_equals(mixed $v1, mixed $v2): bool { }
 
 /**
  * Allows performing binary search on arrays with arbitrary keys.

--- a/teds_arginfo.h
+++ b/teds_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6129168a4090aa5431bfa59b939688f767b6c0e7 */
+ * Stub hash: 161741d7e05588bbc22373d2805699c2c5159ecd */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_any, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterable, Traversable, MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, callback, IS_CALLABLE, 1, "null")
 ZEND_END_ARG_INFO()
 
@@ -11,24 +11,24 @@ ZEND_END_ARG_INFO()
 #define arginfo_Teds_none arginfo_Teds_any
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_includes_value, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterable, Traversable, MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_fold, 0, 3, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterable, Traversable, MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 	ZEND_ARG_TYPE_INFO(0, initial, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_find, 0, 2, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterable, Traversable, MAY_BE_ARRAY, NULL)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, default, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_unique_values, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, iterable, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterable, Traversable, MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_array_value_first, 0, 1, IS_MIXED, 0)
@@ -46,6 +46,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_strict_hash, 0, 1, IS_LONG,
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_strict_equals, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, v1, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO(0, v2, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_binary_search, 0, 2, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, array, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO(0, target, IS_MIXED, 0)
@@ -59,34 +64,36 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_Teds_is_same_array_handle, 0, 2,
 ZEND_END_ARG_INFO()
 
 
-ZEND_FUNCTION(any);
-ZEND_FUNCTION(all);
-ZEND_FUNCTION(none);
-ZEND_FUNCTION(includes_value);
-ZEND_FUNCTION(fold);
-ZEND_FUNCTION(find);
-ZEND_FUNCTION(unique_values);
-ZEND_FUNCTION(array_value_first);
-ZEND_FUNCTION(array_value_last);
-ZEND_FUNCTION(stable_compare);
-ZEND_FUNCTION(strict_hash);
-ZEND_FUNCTION(binary_search);
-ZEND_FUNCTION(is_same_array_handle);
+ZEND_FUNCTION(Teds_any);
+ZEND_FUNCTION(Teds_all);
+ZEND_FUNCTION(Teds_none);
+ZEND_FUNCTION(Teds_includes_value);
+ZEND_FUNCTION(Teds_fold);
+ZEND_FUNCTION(Teds_find);
+ZEND_FUNCTION(Teds_unique_values);
+ZEND_FUNCTION(Teds_array_value_first);
+ZEND_FUNCTION(Teds_array_value_last);
+ZEND_FUNCTION(Teds_stable_compare);
+ZEND_FUNCTION(Teds_strict_hash);
+ZEND_FUNCTION(Teds_strict_equals);
+ZEND_FUNCTION(Teds_binary_search);
+ZEND_FUNCTION(Teds_is_same_array_handle);
 
 
 static const zend_function_entry ext_functions[] = {
-	ZEND_NS_FE("Teds", any, arginfo_Teds_any)
-	ZEND_NS_FE("Teds", all, arginfo_Teds_all)
-	ZEND_NS_FE("Teds", none, arginfo_Teds_none)
-	ZEND_NS_FE("Teds", includes_value, arginfo_Teds_includes_value)
-	ZEND_NS_FE("Teds", fold, arginfo_Teds_fold)
-	ZEND_NS_FE("Teds", find, arginfo_Teds_find)
-	ZEND_NS_FE("Teds", unique_values, arginfo_Teds_unique_values)
-	ZEND_NS_FE("Teds", array_value_first, arginfo_Teds_array_value_first)
-	ZEND_NS_FE("Teds", array_value_last, arginfo_Teds_array_value_last)
-	ZEND_NS_FE("Teds", stable_compare, arginfo_Teds_stable_compare)
-	ZEND_NS_FE("Teds", strict_hash, arginfo_Teds_strict_hash)
-	ZEND_NS_FE("Teds", binary_search, arginfo_Teds_binary_search)
-	ZEND_NS_FE("Teds", is_same_array_handle, arginfo_Teds_is_same_array_handle)
+	ZEND_NS_FALIAS("Teds", any, Teds_any, arginfo_Teds_any)
+	ZEND_NS_FALIAS("Teds", all, Teds_all, arginfo_Teds_all)
+	ZEND_NS_FALIAS("Teds", none, Teds_none, arginfo_Teds_none)
+	ZEND_NS_FALIAS("Teds", includes_value, Teds_includes_value, arginfo_Teds_includes_value)
+	ZEND_NS_FALIAS("Teds", fold, Teds_fold, arginfo_Teds_fold)
+	ZEND_NS_FALIAS("Teds", find, Teds_find, arginfo_Teds_find)
+	ZEND_NS_FALIAS("Teds", unique_values, Teds_unique_values, arginfo_Teds_unique_values)
+	ZEND_NS_FALIAS("Teds", array_value_first, Teds_array_value_first, arginfo_Teds_array_value_first)
+	ZEND_NS_FALIAS("Teds", array_value_last, Teds_array_value_last, arginfo_Teds_array_value_last)
+	ZEND_NS_FALIAS("Teds", stable_compare, Teds_stable_compare, arginfo_Teds_stable_compare)
+	ZEND_NS_FALIAS("Teds", strict_hash, Teds_strict_hash, arginfo_Teds_strict_hash)
+	ZEND_NS_FALIAS("Teds", strict_equals, Teds_strict_equals, arginfo_Teds_strict_equals)
+	ZEND_NS_FALIAS("Teds", binary_search, Teds_binary_search, arginfo_Teds_binary_search)
+	ZEND_NS_FALIAS("Teds", is_same_array_handle, Teds_is_same_array_handle, arginfo_Teds_is_same_array_handle)
 	ZEND_FE_END
 };

--- a/teds_bitvector.stub.php
+++ b/teds_bitvector.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 
 namespace Teds;
 

--- a/teds_bitvector_arginfo.h
+++ b/teds_bitvector_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9b848973ebe38f7ff3041c35cf886f53f012b4ac */
+ * Stub hash: d8e380e507be165e3908eef5d247a0a211315a24 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_BitVector___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_BitVector_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_cachediterable.stub.php
+++ b/teds_cachediterable.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_cachediterable_arginfo.h
+++ b/teds_cachediterable_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: df5e0f1b1f2ea4847c77eef7d0f9aa795e70daf1 */
+ * Stub hash: e58358497f83db0ef8b9d5c905cb3b5d73e08e98 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_CachedIterable___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, iterator, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_CachedIterable_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_deque.stub.php
+++ b/teds_deque.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_deque_arginfo.h
+++ b/teds_deque_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a14c0a93435ea3e23920ecf7e56aae5af92f5540 */
+ * Stub hash: fdc75b6e37e010d169c8291ed5c8b4bc077d10fa */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Deque___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_Deque_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_emptycollection.stub.php
+++ b/teds_emptycollection.stub.php
@@ -1,10 +1,14 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer for enums.
 
-#if PHP_VERSION_ID >= 80100
 namespace Teds;
+
+#if PHP_VERSION_ID >= 80100
 
 /**
  * An EmptySequence is an immutable sequence of length 0.

--- a/teds_emptycollection_arginfo.h
+++ b/teds_emptycollection_arginfo.h
@@ -1,200 +1,367 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4bf165d6bf04621c2aff13d8055f2ed4a93c1e31 */
+ * Stub hash: 1d29400df10620e28be9d1bf888c5101f0eee0c1 */
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_count, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_isEmpty, 0, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_toArray, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_values arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_get, 0, 1, IS_NEVER, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_set, 0, 2, IS_NEVER, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_insert, 0, 1, IS_NEVER, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, values, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_push, 0, 0, IS_NEVER, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, values, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_pop, 0, 0, IS_NEVER, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_unshift arginfo_class_Teds_EmptySequence_push
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_shift arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_first arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_last arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_clear, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_offsetGet, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_offsetExists, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_containsKey arginfo_class_Teds_EmptySequence_offsetExists
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_offsetSet, 0, 2, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_offsetUnset, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, offset, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_indexOf, 0, 1, IS_LONG, 1)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySequence_contains, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_EmptySequence_map, 0, 1, Teds\\EmptySequence, 0)
 	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_EmptySequence_filter, 0, 0, Teds\\EmptySequence, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, callback, IS_CALLABLE, 1, "null")
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_jsonSerialize arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_valid arginfo_class_Teds_EmptySequence_isEmpty
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_current arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_key arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_next arginfo_class_Teds_EmptySequence_clear
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySequence_rewind arginfo_class_Teds_EmptySequence_clear
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_count arginfo_class_Teds_EmptySequence_count
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_isEmpty arginfo_class_Teds_EmptySequence_isEmpty
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_clear arginfo_class_Teds_EmptySequence_clear
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_toArray arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_values arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_keys arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptyMap_offsetGet, 0, 1, IS_NEVER, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptyMap_offsetExists, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptyMap_offsetSet, 0, 2, IS_NEVER, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptyMap_offsetUnset, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_contains arginfo_class_Teds_EmptySequence_contains
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_containsKey arginfo_class_Teds_EmptyMap_offsetExists
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptyMap_get, 0, 1, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO(0, key, IS_MIXED, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, default, IS_MIXED, 0, "null")
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_jsonSerialize arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_valid arginfo_class_Teds_EmptySequence_isEmpty
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_current arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_key arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_next arginfo_class_Teds_EmptySequence_clear
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptyMap_rewind arginfo_class_Teds_EmptySequence_clear
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_count arginfo_class_Teds_EmptySequence_count
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_isEmpty arginfo_class_Teds_EmptySequence_isEmpty
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_clear arginfo_class_Teds_EmptySequence_clear
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_toArray arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_values arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_contains arginfo_class_Teds_EmptySequence_contains
+#endif
 
+#if PHP_VERSION_ID >= 80100
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_EmptySet_add, 0, 1, IS_NEVER, 0)
 	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_remove arginfo_class_Teds_EmptySequence_contains
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_jsonSerialize arginfo_class_Teds_EmptySequence_toArray
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_valid arginfo_class_Teds_EmptySequence_isEmpty
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_current arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_key arginfo_class_Teds_EmptySequence_pop
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_next arginfo_class_Teds_EmptySequence_clear
+#endif
 
+#if PHP_VERSION_ID >= 80100
 #define arginfo_class_Teds_EmptySet_rewind arginfo_class_Teds_EmptySequence_clear
+#endif
 
 
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, count);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, isEmpty);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, toArray);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, get);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, set);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, insert);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, push);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, pop);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, first);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_StrictMinHeap, rewind);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, offsetGet);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, offsetExists);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, offsetSet);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, offsetUnset);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, indexOf);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, map);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, filter);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, valid);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptyMap, offsetGet);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptySequence, contains);
+#endif
+#if PHP_VERSION_ID >= 80100
 ZEND_METHOD(Teds_EmptyMap, get);
+#endif
 
 
+#if PHP_VERSION_ID >= 80100
 static const zend_function_entry class_Teds_EmptySequence_methods[] = {
 	ZEND_ME(Teds_EmptySequence, count, arginfo_class_Teds_EmptySequence_count, ZEND_ACC_PUBLIC)
 	ZEND_ME(Teds_EmptySequence, isEmpty, arginfo_class_Teds_EmptySequence_isEmpty, ZEND_ACC_PUBLIC)
@@ -227,8 +394,10 @@ static const zend_function_entry class_Teds_EmptySequence_methods[] = {
 	ZEND_MALIAS(Teds_StrictMinHeap, rewind, rewind, arginfo_class_Teds_EmptySequence_rewind, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
+#endif
 
 
+#if PHP_VERSION_ID >= 80100
 static const zend_function_entry class_Teds_EmptyMap_methods[] = {
 	ZEND_MALIAS(Teds_EmptySequence, count, count, arginfo_class_Teds_EmptyMap_count, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(Teds_EmptySequence, isEmpty, isEmpty, arginfo_class_Teds_EmptyMap_isEmpty, ZEND_ACC_PUBLIC)
@@ -251,8 +420,10 @@ static const zend_function_entry class_Teds_EmptyMap_methods[] = {
 	ZEND_MALIAS(Teds_StrictMinHeap, rewind, rewind, arginfo_class_Teds_EmptyMap_rewind, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
+#endif
 
 
+#if PHP_VERSION_ID >= 80100
 static const zend_function_entry class_Teds_EmptySet_methods[] = {
 	ZEND_MALIAS(Teds_EmptySequence, count, count, arginfo_class_Teds_EmptySet_count, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(Teds_EmptySequence, isEmpty, isEmpty, arginfo_class_Teds_EmptySet_isEmpty, ZEND_ACC_PUBLIC)
@@ -270,7 +441,10 @@ static const zend_function_entry class_Teds_EmptySet_methods[] = {
 	ZEND_MALIAS(Teds_StrictMinHeap, rewind, rewind, arginfo_class_Teds_EmptySet_rewind, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
+#endif
 
+#if (PHP_VERSION_ID >= 80100)
+#if PHP_VERSION_ID >= 80100
 static zend_class_entry *register_class_Teds_EmptySequence(zend_class_entry *class_entry_Iterator, zend_class_entry *class_entry_Teds_Sequence, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry *class_entry = zend_register_internal_enum("Teds\\EmptySequence", IS_UNDEF, class_Teds_EmptySequence_methods);
@@ -280,7 +454,11 @@ static zend_class_entry *register_class_Teds_EmptySequence(zend_class_entry *cla
 
 	return class_entry;
 }
+#endif
+#endif
 
+#if (PHP_VERSION_ID >= 80100)
+#if PHP_VERSION_ID >= 80100
 static zend_class_entry *register_class_Teds_EmptyMap(zend_class_entry *class_entry_Iterator, zend_class_entry *class_entry_Teds_Map, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry *class_entry = zend_register_internal_enum("Teds\\EmptyMap", IS_UNDEF, class_Teds_EmptyMap_methods);
@@ -290,7 +468,11 @@ static zend_class_entry *register_class_Teds_EmptyMap(zend_class_entry *class_en
 
 	return class_entry;
 }
+#endif
+#endif
 
+#if (PHP_VERSION_ID >= 80100)
+#if PHP_VERSION_ID >= 80100
 static zend_class_entry *register_class_Teds_EmptySet(zend_class_entry *class_entry_Iterator, zend_class_entry *class_entry_Teds_Set, zend_class_entry *class_entry_JsonSerializable)
 {
 	zend_class_entry *class_entry = zend_register_internal_enum("Teds\\EmptySet", IS_UNDEF, class_Teds_EmptySet_methods);
@@ -300,3 +482,5 @@ static zend_class_entry *register_class_Teds_EmptySet(zend_class_entry *class_en
 
 	return class_entry;
 }
+#endif
+#endif

--- a/teds_exceptions.stub.php
+++ b/teds_exceptions.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 
 namespace Teds;
 

--- a/teds_exceptions_arginfo.h
+++ b/teds_exceptions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f80ba92e0f083f5b028415fc6591117add8f1ad6 */
+ * Stub hash: 123bd736be93bced53a74d0b7b6a8463e666336c */
 
 
 

--- a/teds_immutableiterable.stub.php
+++ b/teds_immutableiterable.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_immutableiterable_arginfo.h
+++ b/teds_immutableiterable_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: b99c5b20cb6f949354376325c4bfba6667fe8480 */
+ * Stub hash: 97f56531c62d26f73e695f21e99dc3c29e6a3148 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_ImmutableIterable___construct, 0, 0, 1)
-	ZEND_ARG_TYPE_INFO(0, iterator, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_ImmutableIterable_getIterator, 0, 0, InternalIterator, 0)
@@ -15,7 +15,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableIterable_isE
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_ImmutableIterable_fromPairs, 0, 1, Teds\\ImmutableIterable, 0)
-	ZEND_ARG_TYPE_INFO(0, pairs, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, pairs, Traversable, MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_ImmutableIterable_toPairs, 0, 0, IS_ARRAY, 0)

--- a/teds_immutablesequence.stub.php
+++ b/teds_immutablesequence.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_immutablesequence_arginfo.h
+++ b/teds_immutablesequence_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e26a35fe06208ce66ba1da278adf6c4436f12cf7 */
+ * Stub hash: 2867fca8cf5f28bc2095c30dc55142834f14176f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_ImmutableSequence___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_ImmutableSequence_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_immutablesortedstringset.stub.php
+++ b/teds_immutablesortedstringset.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 
 namespace Teds;
 

--- a/teds_immutablesortedstringset_arginfo.h
+++ b/teds_immutablesortedstringset_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d8840a8fff92b44ddd7480325e6517a113a26ed8 */
+ * Stub hash: 42ed930a6d9d3f66a77a798d80bdbcbe95c81767 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_ImmutableSortedStringSet___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_ImmutableSortedStringSet_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_interfaces.stub.php
+++ b/teds_interfaces.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 
 namespace Teds;
 

--- a/teds_interfaces_arginfo.h
+++ b/teds_interfaces_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 45c5681cfc9b1ad889eb715fdaea3873f5947641 */
+ * Stub hash: 5b54601586b4c56aeb4376325c512912ca81d291 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_Collection_values, 0, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()

--- a/teds_intvector.stub.php
+++ b/teds_intvector.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 
 namespace Teds;
 

--- a/teds_intvector_arginfo.h
+++ b/teds_intvector_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e7a2e4f36e7560096e20279277c34a14910d3d76 */
+ * Stub hash: ed3bb1c3bb007c2a234cdface597485a32281424 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_IntVector___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_IntVector_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_lowmemoryvector.stub.php
+++ b/teds_lowmemoryvector.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 
 namespace Teds;
 

--- a/teds_lowmemoryvector_arginfo.h
+++ b/teds_lowmemoryvector_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9e5bbfe15930d8d7c192f46129f54618b9ce3eb4 */
+ * Stub hash: b70ce83598e0eb50277e025afa6fb2e408fc6d85 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_LowMemoryVector___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_LowMemoryVector_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_mutableiterable.stub.php
+++ b/teds_mutableiterable.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_mutableiterable_arginfo.h
+++ b/teds_mutableiterable_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 195300884310ffca7e55f4a3eda360bf954c404d */
+ * Stub hash: 862b5f703882403e46e0563e134a21a9d1650345 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_MutableIterable___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_MutableIterable_getIterator, 0, 0, InternalIterator, 0)
@@ -24,7 +24,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_MutableIterable_setSi
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_MutableIterable_fromPairs, 0, 1, Teds\\MutableIterable, 0)
-	ZEND_ARG_TYPE_INFO(0, pairs, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, pairs, Traversable, MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_MutableIterable_toPairs, 0, 0, IS_ARRAY, 0)

--- a/teds_stricthashmap.stub.php
+++ b/teds_stricthashmap.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_stricthashmap_arginfo.h
+++ b/teds_stricthashmap_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 205a459f0b6c67c8214b86498b823db235391414 */
+ * Stub hash: 01afd04d88f7d69bac94516a4d94ef1c02064e5e */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictHashMap___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictHashMap_getIterator, 0, 0, InternalIterator, 0)
@@ -21,7 +21,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_StrictHashMap_toPairs
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictHashMap_fromPairs, 0, 1, Teds\\StrictHashMap, 0)
-	ZEND_ARG_TYPE_INFO(0, pairs, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, pairs, Traversable, MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_StrictHashMap___serialize arginfo_class_Teds_StrictHashMap_toPairs

--- a/teds_stricthashset.stub.php
+++ b/teds_stricthashset.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_stricthashset_arginfo.h
+++ b/teds_stricthashset_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7e16928238e2f1f94c53d9e4bd54eb5009999a08 */
+ * Stub hash: e5003b4aa81c50dee2c963daa9bfd986001593c9 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictHashSet___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictHashSet_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_strictheap.stub.php
+++ b/teds_strictheap.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_strictheap_arginfo.h
+++ b/teds_strictheap_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 900417fcee104b28d6f6bf0de7f7c7d4ade5e03f */
+ * Stub hash: feadac93e5ed629e353af2806fc1d1030dd87699 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictMinHeap___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, values, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, values, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_StrictMinHeap_add, 0, 1, IS_VOID, 0)

--- a/teds_strictsortedvectormap.stub.php
+++ b/teds_strictsortedvectormap.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_strictsortedvectormap_arginfo.h
+++ b/teds_strictsortedvectormap_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5324838f41d765ad3b32b288c78d0e872d45353f */
+ * Stub hash: 121558f30006a840e719a715fce1b48b61c5eb2f */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictSortedVectorMap___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictSortedVectorMap_getIterator, 0, 0, InternalIterator, 0)
@@ -21,7 +21,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Teds_StrictSortedVectorMap
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictSortedVectorMap_fromPairs, 0, 1, Teds\\StrictSortedVectorMap, 0)
-	ZEND_ARG_TYPE_INFO(0, pairs, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, pairs, Traversable, MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_StrictSortedVectorMap___serialize arginfo_class_Teds_StrictSortedVectorMap_toPairs

--- a/teds_strictsortedvectorset.stub.php
+++ b/teds_strictsortedvectorset.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_strictsortedvectorset_arginfo.h
+++ b/teds_strictsortedvectorset_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0e3b9ccfccb544b1a63ee1ea4f2a892bf6a7cf44 */
+ * Stub hash: ebc6c55cb287019d4e788153a26ea9f558146223 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictSortedVectorSet___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictSortedVectorSet_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_stricttreemap.stub.php
+++ b/teds_stricttreemap.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_stricttreemap_arginfo.h
+++ b/teds_stricttreemap_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: d1bef3adc48598684a70bee5613088b1feea1c6b */
+ * Stub hash: a63005f2026895e1c0b170a70d1f57987dd785ad */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictTreeMap___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictTreeMap_getIterator, 0, 0, InternalIterator, 0)
@@ -23,7 +23,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Teds_StrictTreeMap_toArray arginfo_class_Teds_StrictTreeMap_toPairs
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictTreeMap_fromPairs, 0, 1, Teds\\StrictTreeMap, 0)
-	ZEND_ARG_TYPE_INFO(0, pairs, IS_ITERABLE, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, pairs, Traversable, MAY_BE_ARRAY, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Teds_StrictTreeMap___serialize arginfo_class_Teds_StrictTreeMap_toPairs

--- a/teds_stricttreeset.stub.php
+++ b/teds_stricttreeset.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 // Stub generation requires build/gen_stub.php from php 8.1 or newer.
 
 namespace Teds;

--- a/teds_stricttreeset_arginfo.h
+++ b/teds_stricttreeset_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 35f151d7506c7ab60268b8054fe6a7dcfc934355 */
+ * Stub hash: 2313b06f0da996785ea6d93252c86500d90d8a26 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_StrictTreeSet___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_StrictTreeSet_getIterator, 0, 0, InternalIterator, 0)

--- a/teds_vector.stub.php
+++ b/teds_vector.stub.php
@@ -1,6 +1,9 @@
 <?php
 
-/** @generate-class-entries */
+/**
+ * @generate-class-entries
+ * @generate-legacy-arginfo 80000
+ */
 
 namespace Teds;
 

--- a/teds_vector_arginfo.h
+++ b/teds_vector_arginfo.h
@@ -1,8 +1,8 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f7875384e8821ce5b245bb44b58075b51aada9a8 */
+ * Stub hash: 34cbebeaab2ca048d72077ab941af4bf79fca900 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Teds_Vector___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, iterator, IS_ITERABLE, 0, "[]")
+	ZEND_ARG_OBJ_TYPE_MASK(0, iterator, Traversable, MAY_BE_ARRAY, "[]")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Teds_Vector_getIterator, 0, 0, InternalIterator, 0)

--- a/tests/misc/strict_equals.phpt
+++ b/tests/misc/strict_equals.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Test strict_equals() function
+--FILE--
+<?php
+
+function dump_strict_equals(mixed $a, mixed $b) {
+    printf("Teds\strict_equals(%s, %s): %s\n", var_export($a, true), var_export($b, true), var_export(Teds\strict_equals($a, $b), true));
+}
+$zero = 0.0;
+$values = [
+    null,
+    false,
+    true,
+    -1,
+    0,
+    0.0,
+    -0.0,  // Deliberately return the same hash as 0.0, because php has 0.0 === -0.0 and it's equivalent in *almost* all ways, apart from 1 / -0.0
+    'str',
+    new stdClass(),
+    function () {},
+    STDIN,
+    INF,
+    -INF,
+    NAN,
+    fdiv($zero, $zero),
+    [NAN],
+];
+
+foreach ($values as $value) {
+    dump_strict_equals($value, $value);
+}
+$aNAN = [];
+$nan = NAN;
+$aNAN[] = &$nan;
+dump_strict_equals([NAN], $aNAN);
+
+echo "Not equals\n";
+dump_strict_equals(NAN, INF);
+dump_strict_equals([NAN], [INF]);
+
+?>
+--EXPECTF--
+Teds\strict_equals(NULL, NULL): true
+Teds\strict_equals(false, false): true
+Teds\strict_equals(true, true): true
+Teds\strict_equals(-1, -1): true
+Teds\strict_equals(0, 0): true
+Teds\strict_equals(0.0, 0.0): true
+Teds\strict_equals(-0.0, -0.0): true
+Teds\strict_equals('str', 'str'): true
+Teds\strict_equals((object) array(
+), (object) array(
+)): true
+Teds\strict_equals(%SClosure::__set_state(array(
+)), %SClosure::__set_state(array(
+))): true
+Teds\strict_equals(NULL, NULL): true
+Teds\strict_equals(INF, INF): true
+Teds\strict_equals(-INF, -INF): true
+Teds\strict_equals(NAN, NAN): true
+Teds\strict_equals(NAN, NAN): true
+Teds\strict_equals(array (
+  0 => NAN,
+), array (
+  0 => NAN,
+)): true
+Teds\strict_equals(array (
+  0 => NAN,
+), array (
+  0 => NAN,
+)): true
+Not equals
+Teds\strict_equals(NAN, INF): false
+Teds\strict_equals(array (
+  0 => NAN,
+), array (
+  0 => INF,
+)): false

--- a/tests/reflection.phpt
+++ b/tests/reflection.phpt
@@ -101,5 +101,6 @@ Teds\includes_value
 Teds\is_same_array_handle
 Teds\none
 Teds\stable_compare
+Teds\strict_equals
 Teds\strict_hash
 Teds\unique_values


### PR DESCRIPTION
Regenerate arginfo with php 8.3-dev's build/gen_stubs.php

- Adding the @generate-legacy-arginfo 80000 for minimum php 8.0 version compatibility turned out to be unnecessary.

Add `Teds\strict_equals` as used by hash sets/maps and unique_values