### PR TITLE
relax test expectations for 8.3

### DIFF
--- a/tests/Map/toArray.phpt
+++ b/tests/Map/toArray.phpt
@@ -26,7 +26,7 @@ foreach ([
     test_to_array($class);
 }
 ?>
---EXPECT--
+--EXPECTF--
 Test Teds\StrictSortedVectorMap
 array(2) {
   ["def"]=>
@@ -35,7 +35,7 @@ array(2) {
   ["v_abc"]=>
   string(3) "v_x"
 }
-Caught: Illegal offset type
+Caught: %s offset %s
 Test Teds\StrictTreeMap
 array(2) {
   ["def"]=>
@@ -44,7 +44,7 @@ array(2) {
   ["v_abc"]=>
   string(3) "v_x"
 }
-Caught: Illegal offset type
+Caught: %s offset %s
 Test Teds\StrictHashMap
 array(2) {
   ["v_abc"]=>
@@ -53,4 +53,4 @@ array(2) {
   object(stdClass)#2 (0) {
   }
 }
-Caught: Illegal offset type
+Caught: %s offset %s

--- a/tests/iterable/all_array.phpt
+++ b/tests/iterable/all_array.phpt
@@ -51,9 +51,9 @@ echo "\nDone";
 --EXPECTF--
 *** Testing not enough or wrong arguments ***
 Caught ArgumentCountError: Teds\all() expects at least 1 argument, 0 given
-Caught TypeError: Teds\all(): Argument #1 ($iterable) must be of type %s, bool given
+Caught TypeError: Teds\all(): Argument #1 ($iterable) must be of type %s, %s given
 bool(true)
-Caught TypeError: Teds\all(): Argument #1 ($iterable) must be of type %s, bool given
+Caught TypeError: Teds\all(): Argument #1 ($iterable) must be of type %s, %s given
 Caught TypeError: Teds\all(): Argument #2 ($callback) must be a valid callback%S, no array or string given
 
 *** Testing basic functionality ***

--- a/tests/iterable/any_array.phpt
+++ b/tests/iterable/any_array.phpt
@@ -60,9 +60,9 @@ echo "\nDone";
 --EXPECTF--
 *** Testing not enough or wrong arguments ***
 Caught ArgumentCountError: Teds\any() expects at least 1 argument, 0 given
-Caught TypeError: Teds\any(): Argument #1 ($iterable) must be of type %s, bool given
+Caught TypeError: Teds\any(): Argument #1 ($iterable) must be of type %s, %s given
 bool(false)
-Caught TypeError: Teds\any(): Argument #1 ($iterable) must be of type %s, bool given
+Caught TypeError: Teds\any(): Argument #1 ($iterable) must be of type %s, %s given
 Caught TypeError: Teds\any(): Argument #2 ($callback) must be a valid callback%S, no array or string given
 
 *** Testing basic functionality ***

--- a/tests/iterable/none_array.phpt
+++ b/tests/iterable/none_array.phpt
@@ -60,9 +60,9 @@ echo "\nDone";
 --EXPECTF--
 *** Testing not enough or wrong arguments ***
 Caught ArgumentCountError: Teds\none() expects at least 1 argument, 0 given
-Caught TypeError: Teds\none(): Argument #1 ($iterable) must be of type %s, bool given
+Caught TypeError: Teds\none(): Argument #1 ($iterable) must be of type %s, %s given
 bool(true)
-Caught TypeError: Teds\none(): Argument #1 ($iterable) must be of type %s, bool given
+Caught TypeError: Teds\none(): Argument #1 ($iterable) must be of type %s, %s given
 Caught TypeError: Teds\none(): Argument #2 ($callback) must be a valid callback%S, no array or string given
 
 *** Testing basic functionality ***


### PR DESCRIPTION
Without:

```
========DIFF========
     *** Testing not enough or wrong arguments ***
     Caught ArgumentCountError: Teds\all() expects at least 1 argument, 0 given
003- Caught TypeError: Teds\all(): Argument #1 ($iterable) must be of type %s, bool given
003+ Caught TypeError: Teds\all(): Argument #1 ($iterable) must be of type Traversable|array, true given
     bool(true)
005- Caught TypeError: Teds\all(): Argument #1 ($iterable) must be of type %s, bool given
005+ Caught TypeError: Teds\all(): Argument #1 ($iterable) must be of type Traversable|array, true given
     Caught TypeError: Teds\all(): Argument #2 ($callback) must be a valid callback%S, no array or string given
     
     *** Testing basic functionality ***
--
========DONE========
FAIL Test all() function [tests/iterable/all_array.phpt] 

========DIFF========
     *** Testing not enough or wrong arguments ***
     Caught ArgumentCountError: Teds\any() expects at least 1 argument, 0 given
003- Caught TypeError: Teds\any(): Argument #1 ($iterable) must be of type %s, bool given
003+ Caught TypeError: Teds\any(): Argument #1 ($iterable) must be of type Traversable|array, true given
     bool(false)
005- Caught TypeError: Teds\any(): Argument #1 ($iterable) must be of type %s, bool given
005+ Caught TypeError: Teds\any(): Argument #1 ($iterable) must be of type Traversable|array, true given
     Caught TypeError: Teds\any(): Argument #2 ($callback) must be a valid callback%S, no array or string given
     
     *** Testing basic functionality ***
--
========DONE========
FAIL Test any() function [tests/iterable/any_array.phpt] 

========DIFF========
     *** Testing not enough or wrong arguments ***
     Caught ArgumentCountError: Teds\none() expects at least 1 argument, 0 given
003- Caught TypeError: Teds\none(): Argument #1 ($iterable) must be of type %s, bool given
003+ Caught TypeError: Teds\none(): Argument #1 ($iterable) must be of type Traversable|array, true given
     bool(true)
005- Caught TypeError: Teds\none(): Argument #1 ($iterable) must be of type %s, bool given
005+ Caught TypeError: Teds\none(): Argument #1 ($iterable) must be of type Traversable|array, true given
     Caught TypeError: Teds\none(): Argument #2 ($callback) must be a valid callback%S, no array or string given
     
     *** Testing basic functionality ***
--
========DONE========
FAIL Test none() function [tests/iterable/none_array.phpt] 

--
       ["v_abc"]=>
       string(3) "v_x"
     }
009- Caught: Illegal offset type
009+ Caught: Cannot access offset of type array on array
     Test Teds\StrictTreeMap
     array(2) {
       ["def"]=>
--
       ["v_abc"]=>
       string(3) "v_x"
     }
018- Caught: Illegal offset type
018+ Caught: Cannot access offset of type array on array
     Test Teds\StrictHashMap
     array(2) {
       ["v_abc"]=>
--
       object(stdClass)#2 (0) {
       }
     }
027- Caught: Illegal offset type
027+ Caught: Cannot access offset of type array on array
========DONE========
FAIL Teds\Collection toArray() [tests/Map/toArray.phpt] 

```